### PR TITLE
Add ruff linting, formatting, and pre-commit hooks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,14 +1,30 @@
 name: Python package
 
-on: 
+on:
   push:
     branches:
       - '*'
   workflow_call: {}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff linter
+        run: ruff check --output-format=github src/
+      - name: Run ruff formatter check
+        run: ruff format --check src/
+
   unit-tests:
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       matrix:
         python-version: ["3.10","3.11", "3.12", "3.13"]
@@ -28,12 +44,6 @@ jobs:
         run: |
           pip install libs/oceanum-python
           pip install .[test]
-      - name: Lint code with Ruff
+      - name: Run unit-tests with parallel execution
         run: |
-          pip install ruff
-          ruff check --output-format=github --target-version=py310 --exclude=tests --exclude=oceanum-python
-        continue-on-error: true
-      - name: Run unit-tests
-        run: |
-          pytest --cov oceanum.cli.prax tests/ -s -v
-      
+          pytest --cov oceanum.cli.prax tests/ -n auto -v

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # Spyder project settings
 .spyderproject
@@ -163,3 +164,4 @@ cython_debug/
 #.idea/
 
 .ruff_cache/
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Pre-commit hooks for code quality
+# See https://pre-commit.com for more information
+# Install: pip install pre-commit && pre-commit install
+
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+
+repos:
+  # Ruff - Fast Python linter and formatter (replaces black, isort, flake8, etc.)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      # Run the linter
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      # Run the formatter
+      - id: ruff-format
+
+  # General file cleanup hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^tests/fixtures/
+      - id: end-of-file-fixer
+        exclude: ^tests/fixtures/
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-ast  # Validate Python syntax
+      - id: debug-statements  # Check for debugger imports

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oceanum PRAX CLI 
+# Oceanum PRAX CLI
 *(Platform for Rapid Application Execution)*
 
 Deploy and manage your projects on Oceanum.io PRAX platform. In the PRAX platform, you can deploy  applications in a serverless environment and run them in a secure and scalable way. The main components of the PRAX platform are:
@@ -27,3 +27,45 @@ oceanum prax --help
 ## Documentation
 
 ReadTheDocs: [https://oceanum-prax-cli.readthedocs.io/](https://oceanum-prax-cli.readthedocs.io/en/)
+
+## Development
+
+### Setup
+
+1. Clone the repository
+2. Install development dependencies:
+   ```bash
+   pip install -e .[dev,test]
+   ```
+3. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+### Code Quality
+
+This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting:
+
+- **Lint code**: `ruff check src/`
+- **Format code**: `ruff format src/`
+- **Auto-fix issues**: `ruff check --fix src/`
+
+Pre-commit hooks will automatically format code and check for issues before each commit.
+
+### Testing
+
+Run tests with parallel execution:
+```bash
+pytest -n auto
+```
+
+Run tests with coverage:
+```bash
+pytest --cov oceanum.cli.prax tests/ -n auto -v
+```
+
+### Configuration
+
+- **Ruff**: Configured in `pyproject.toml` with 88-character line length
+- **Pre-commit**: Configured in `.pre-commit-config.yaml`
+- **Python versions**: 3.10, 3.11, 3.12, 3.13

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'oceanum-prax'
-copyright = '2025, Oceanum Developers'
-author = 'Oceanum Developers'
+project = "oceanum-prax"
+copyright = "2025, Oceanum Developers"
+author = "Oceanum Developers"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -19,11 +19,11 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinxcontrib.autodoc_pydantic",
-    "sphinxcontrib.programoutput",    
+    "sphinxcontrib.programoutput",
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_favicon = "favicon.ico"
 html_theme_options = {
@@ -31,8 +31,8 @@ html_theme_options = {
     "show_nav_level": 2,
     "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
     "logo": {
-      "image_light": "oceanum-secondary-logo-marine-rgb.svg",
-      "image_dark": "oceanum-secondary-logo-powder-blue-rgb.svg",
+        "image_light": "oceanum-secondary-logo-marine-rgb.svg",
+        "image_dark": "oceanum-secondary-logo-powder-blue-rgb.svg",
     },
     "icon_links": [
         {
@@ -52,5 +52,5 @@ html_sidebars = {
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'pydata_sphinx_theme'
-html_static_path = ['_static']
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov", "ruff"]
+test = ["pytest", "pytest-cov", "pytest-xdist"]
+dev = ["ruff", "pre-commit"]
 modelgen = ["datamodel-code-generator[http]"]
 
 [project.entry-points."oceanum.cli.extensions"]
@@ -82,3 +83,50 @@ exclude = ["tests*"]
 
 [tool.distutils.bdist_wheel]
 universal = true
+
+# Ruff configuration - Modern Python linter and formatter
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+# Exclude auto-generated files and build artifacts
+extend-exclude = [
+    "src/oceanum/cli/prax/models.py",  # Auto-generated from OpenAPI
+    "build",
+    "dist",
+    ".eggs",
+    "*.egg-info",
+]
+
+[tool.ruff.lint]
+# Start with lenient rules - focus on clear errors and consistency
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes (unused imports, undefined names, etc.)
+    "I",    # isort (import sorting)
+    "W",    # pycodestyle warnings
+]
+
+# Ignore rules that conflict with formatter or are too strict initially
+ignore = [
+    "E501",  # Line too long (let formatter handle line length)
+    "E731",  # Lambda assignment (lenient - can be useful for inline functions)
+]
+
+# Per-file ignores
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "F841",  # Unused variable (common in test fixtures/mocks)
+]
+
+# Sort imports automatically
+[tool.ruff.lint.isort]
+known-first-party = ["oceanum"]
+combine-as-imports = true
+
+# Formatter configuration
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/src/oceanum/cli/prax/__init__.py
+++ b/src/oceanum/cli/prax/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "0.9.2"
+
+# Import command modules to register decorators
+from . import main, project, route, user, workflows  # noqa: F401

--- a/src/oceanum/cli/prax/client.py
+++ b/src/oceanum/cli/prax/client.py
@@ -1,66 +1,70 @@
-
 import os
-import yaml
 import time
 from datetime import timedelta
 from pathlib import Path
-from typing import Literal, Optional, Type, Iterable, Any
+from typing import Any, Iterable, Literal, Optional, Type
 
 import click
 import humanize
 import requests
-from pydantic import SecretStr, RootModel, Field, model_validator, ValidationError
+import yaml
+from pydantic import Field, RootModel, SecretStr, ValidationError, model_validator
 
-from oceanum.cli.symbols import spin, chk, err, wrn, watch, globe
+from oceanum.cli.symbols import chk, err, globe, spin, watch, wrn
+
 from . import models
 from .utils import format_route_status as _frs
 
-class RevealedSecretStr(RootModel):
-    root: Optional[str|SecretStr] = None
 
-    @model_validator(mode='after')
+class RevealedSecretStr(RootModel):
+    root: Optional[str | SecretStr] = None
+
+    @model_validator(mode="after")
     def validate_revealed_secret_str(self):
         if isinstance(self.root, SecretStr):
             self.root = self.root.get_secret_value()
-        return self            
-    
+        return self
+
+
 class RevealedSecretData(models.SecretData):
     root: Optional[dict[str, RevealedSecretStr]] = None
+
 
 class RevealedSecretSpec(models.SecretSpec):
     data: Optional[RevealedSecretData] = None
 
+
 class RevealedSecretsBuildCredentials(models.BuildCredentials):
     password: Optional[RevealedSecretStr] = None
+
 
 class RevealedSecretsBuildSpec(models.BuildSpec):
     credentials: Optional[RevealedSecretsBuildCredentials] = None
 
+
 class RevealedSecretsCustomDomainSpec(models.CustomDomainSpec):
-    tls_cert: Optional[RevealedSecretStr] = Field(
-        default=None, 
-        alias='tlsCert'
-    )
-    tls_key: Optional[RevealedSecretStr] = Field(
-        default=None, 
-        alias='tlsKey'
-    )
+    tls_cert: Optional[RevealedSecretStr] = Field(default=None, alias="tlsCert")
+    tls_key: Optional[RevealedSecretStr] = Field(default=None, alias="tlsKey")
+
 
 class RevealedSecretsRouteSpec(models.ServiceRouteSpec):
     custom_domains: Optional[list[RevealedSecretsCustomDomainSpec]] = Field(
-        default=None, 
-        alias='customDomains'
+        default=None, alias="customDomains"
     )
+
 
 class RevealedSecretsServiceSpec(models.ServiceSpec):
     routes: Optional[list[RevealedSecretsRouteSpec]] = None
+
 
 class RevealedSecretsImageSpec(models.ImageSpec):
     username: Optional[RevealedSecretStr] = None
     password: Optional[RevealedSecretStr] = None
 
+
 class RevealedSecretsSourceRepositorySpec(models.SourceRepositorySpec):
     token: Optional[RevealedSecretStr] = None
+
 
 class RevealedSecretProjectResourcesSpec(models.ProjectResourcesSpec):
     secrets: Optional[list[RevealedSecretSpec]] = None
@@ -68,106 +72,119 @@ class RevealedSecretProjectResourcesSpec(models.ProjectResourcesSpec):
     images: Optional[list[RevealedSecretsImageSpec]] = None
     sources: Optional[list[RevealedSecretsSourceRepositorySpec]] = None
 
+
 class RevealedSecretsProjectSpec(models.ProjectSpec):
     resources: Optional[RevealedSecretProjectResourcesSpec] = None
 
+
 def dump_with_secrets(spec: models.ProjectSpec) -> dict:
     spec_dict = spec.model_dump(
-        exclude_none=True,
-        exclude_unset=True,
-        by_alias=True,
-        mode='python'
+        exclude_none=True, exclude_unset=True, by_alias=True, mode="python"
     )
     return RevealedSecretsProjectSpec(**spec_dict).model_dump(
-        exclude_none=True,
-        exclude_unset=True,
-        by_alias=True,
-        mode='json'
+        exclude_none=True, exclude_unset=True, by_alias=True, mode="json"
     )
 
 
 class PRAXClient:
-    def __init__(self, ctx: click.Context|None = None, token: str|None = None, service: str|None = None) -> None:
+    def __init__(
+        self,
+        ctx: click.Context | None = None,
+        token: str | None = None,
+        service: str | None = None,
+    ) -> None:
         if ctx is not None:
             if ctx.obj.token:
                 self.token = f"Bearer {ctx.obj.token.access_token}"
             else:
-                self.token = token or os.getenv('PRAX_API_TOKEN')
-                
-            if ctx.obj.domain.startswith('oceanum.'):
-                self.service = f'https://PRAX.{ctx.obj.domain}/api'
+                self.token = token or os.getenv("PRAX_API_TOKEN")
+
+            if ctx.obj.domain.startswith("oceanum."):
+                self.service = f"https://PRAX.{ctx.obj.domain}/api"
             else:
-                self.service = service or os.getenv('PRAX_API_URL')
-        
+                self.service = service or os.getenv("PRAX_API_URL")
+
         self.ctx = ctx
-        self._lag = 2 # seconds
+        self._lag = 2  # seconds
         self._deploy_start_time = time.time()
 
-    def _request(self, 
-        method: Literal['GET', 'POST', 'PUT','DELETE','PATCH'], 
+    def _request(
+        self,
+        method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"],
         endpoint,
-        schema: Type[models.BaseModel]|None = None,
-        **kwargs
-    ) -> tuple[Any|requests.Response, models.ErrorResponse|None]:
-        assert self.service is not None, 'Service URL is required'
+        schema: Type[models.BaseModel] | None = None,
+        **kwargs,
+    ) -> tuple[Any | requests.Response, models.ErrorResponse | None]:
+        assert self.service is not None, "Service URL is required"
         if self.token is not None:
-            headers = kwargs.pop('headers', {})|{
-                'Authorization': f'{self.token}'
-            }
+            headers = kwargs.pop("headers", {}) | {"Authorization": f"{self.token}"}
         else:
-            headers = kwargs.pop('headers', {})
+            headers = kwargs.pop("headers", {})
         url = f"{self.service.removesuffix('/')}/{endpoint}"
         response = requests.request(method, url, headers=headers, **kwargs)
         errs = self._handle_errors(response)
         obj = None
         if not errs and schema is not None:
             obj = self._validate_schema(response, schema)
-        return obj if obj is not None else response,  errs
-    
+        return obj if obj is not None else response, errs
+
     def _wait_project_commit(self, **params) -> bool:
         while True:
             project = self.get_project(**params)
-            if isinstance(project, models.ProjectDetailsSchema) and project.last_revision is not None:
-                if project.last_revision.status == 'created':
+            if (
+                isinstance(project, models.ProjectDetailsSchema)
+                and project.last_revision is not None
+            ):
+                if project.last_revision.status == "created":
                     time.sleep(self._lag)
-                    click.echo(f' {spin} Waiting for Revision #{project.last_revision.number} to be committed...')
+                    click.echo(
+                        f" {spin} Waiting for Revision #{project.last_revision.number} to be committed..."
+                    )
                     continue
-                elif project.last_revision.status == 'no-change':
-                    click.echo(f' {wrn} No changes to commit, exiting...')
+                elif project.last_revision.status == "no-change":
+                    click.echo(f" {wrn} No changes to commit, exiting...")
                     return False
-                elif project.last_revision.status == 'failed':
-                    click.echo(f" {err} Revision #{project.last_revision.number} failed to commit, exiting...")
+                elif project.last_revision.status == "failed":
+                    click.echo(
+                        f" {err} Revision #{project.last_revision.number} failed to commit, exiting..."
+                    )
                     return False
-                elif project.last_revision.status == 'commited':
-                    click.echo(f" {chk} Revision #{project.last_revision.number} committed successfully")
+                elif project.last_revision.status == "commited":
+                    click.echo(
+                        f" {chk} Revision #{project.last_revision.number} committed successfully"
+                    )
                     return True
             else:
-                click.echo(f' {err} No project revision found, exiting...')
+                click.echo(f" {err} No project revision found, exiting...")
                 break
         return True
-    
+
     def _wait_stages_start_updating(self, **params):
         counter = 0
         while True:
             project = self.get_project(**params)
             if isinstance(project, models.ProjectDetailsSchema):
-                updating = any([s.status in ['updating','degraded'] for s in project.stages])
-                ready_stages = all([s.status in ['ready', 'error'] for s in project.stages])
+                updating = any(
+                    [s.status in ["updating", "degraded"] for s in project.stages]
+                )
+                ready_stages = all(
+                    [s.status in ["ready", "error"] for s in project.stages]
+                )
                 if updating:
                     break
                 elif counter > 5 and ready_stages:
-                    #click.echo(f"Project '{project.name}' finished being updated in {time.time()-start:.2f}s")
+                    # click.echo(f"Project '{project.name}' finished being updated in {time.time()-start:.2f}s")
                     break
                 else:
-                    click.echo(f' {spin} Waiting for project to start updating...')
+                    click.echo(f" {spin} Waiting for project to start updating...")
                     pass
                     time.sleep(self._lag)
                     counter += 1
                 return project
             else:
-                click.echo(f' {err} Failed to get project details!')
+                click.echo(f" {err} Failed to get project details!")
                 break
-    
+
     def _wait_builds_to_finish(self, **params):
         def get_builds(project) -> list[models.BuildSchema]:
             builds = self.list_builds(project=project.name, org=project.org)
@@ -175,15 +192,18 @@ class PRAXClient:
                 click.echo(f" {err} Failed to get project builds!")
                 return []
             return builds
-        
+
         project = self.get_project(**params)
-        
-        if isinstance(project, models.ProjectDetailsSchema) and project.last_revision is not None:
-            params['project'] = params.pop('project_name', project.name)
-            
+
+        if (
+            isinstance(project, models.ProjectDetailsSchema)
+            and project.last_revision is not None
+        ):
+            params["project"] = params.pop("project_name", project.name)
+
             spec = project.last_revision.spec
             builds = spec.resources.builds if spec.resources else None
-            
+
             if not builds:
                 return True
 
@@ -195,42 +215,64 @@ class PRAXClient:
                 project_builds = get_builds(project)
                 if not project_builds:
                     continue
-                
-                finished_builds = [b for b in project_builds if b.last_run and b.last_run.status in ['Succeeded','Failed','Error']]
-                running_builds = [b for b in project_builds if b.last_run and b.last_run.status in ['Pending','Running']]
-                
+
+                finished_builds = [
+                    b
+                    for b in project_builds
+                    if b.last_run
+                    and b.last_run.status in ["Succeeded", "Failed", "Error"]
+                ]
+                running_builds = [
+                    b
+                    for b in project_builds
+                    if b.last_run and b.last_run.status in ["Pending", "Running"]
+                ]
+
                 if project_builds == finished_builds:
                     click.echo(f" {chk} All builds finished!")
                     for build in project_builds:
-                        if build.last_run and build.last_run.status in ['Failed','Error']:
-                            click.echo(f" {err} Build '{build.name}-{build.stage}' failed to start or while running!")
-                            click.echo(f"Inspect Build Run logs with 'oceanum prax logs build {build.name} --project {project.name} --org {project.org} --stage {build.stage}' command !")
+                        if build.last_run and build.last_run.status in [
+                            "Failed",
+                            "Error",
+                        ]:
+                            click.echo(
+                                f" {err} Build '{build.name}-{build.stage}' failed to start or while running!"
+                            )
+                            click.echo(
+                                f"Inspect Build Run logs with 'oceanum prax logs build {build.name} --project {project.name} --org {project.org} --stage {build.stage}' command !"
+                            )
                             return False
-                        elif build.last_run and build.last_run.status == 'Succeeded':
-                            click.echo(f" {chk} Build '{build.name}-{build.stage}' finished successfully!")
+                        elif build.last_run and build.last_run.status == "Succeeded":
+                            click.echo(
+                                f" {chk} Build '{build.name}-{build.stage}' finished successfully!"
+                            )
                     break
                 elif running_builds:
                     if not to_finish_msg:
-                        click.echo(f" {spin} Waiting for builds to finish, this can take several minutes...")
+                        click.echo(
+                            f" {spin} Waiting for builds to finish, this can take several minutes..."
+                        )
                         to_finish_msg = True
                     continue
         else:
             click.echo(f" {err} Failed to get project details!")
             return False
         return True
-            
+
     def _wait_stages_finish_updating(self, **params):
         counter = 0
-        click.echo(f' {spin} Waiting for all stages to finish updating...')
+        click.echo(f" {spin} Waiting for all stages to finish updating...")
         while True:
             counter += 1
             project = self.get_project(**params)
             if isinstance(project, models.ProjectDetailsSchema):
-                project_name = project.name if project else 'unknown'
+                project_name = project.name if project else "unknown"
                 stages = project.stages or []
-                all_finished = all([s.status in ['healthy', 'error'] for s in stages])
+                all_finished = all([s.status in ["healthy", "error"] for s in stages])
                 if all_finished:
-                    click.echo(f" {chk} Project '{project_name}' finished being updated!")
+                    click.echo(
+                        f" {chk} Project '{project_name}' finished being updated!"
+                    )
                     break
                 elif counter > 10:
                     routes_error = False
@@ -238,10 +280,20 @@ class PRAXClient:
                     for stage in stages:
                         if stage.resources:
                             for route in stage.resources.routes:
-                                if getattr(route.next_revision_status,'root',route.next_revision_status) in ['error']:
-                                    click.echo(f" {err} Route '{route.name}' at revision #{project.last_revision.number} failed to start!")
-                                    msg = (route.details or {}).get('message', 'No error message provided')
-                                    click.echo(f" {wrn} See container error details:{os.linesep}{os.linesep}{msg}")
+                                if getattr(
+                                    route.next_revision_status,
+                                    "root",
+                                    route.next_revision_status,
+                                ) in ["error"]:
+                                    click.echo(
+                                        f" {err} Route '{route.name}' at revision #{project.last_revision.number} failed to start!"
+                                    )
+                                    msg = (route.details or {}).get(
+                                        "message", "No error message provided"
+                                    )
+                                    click.echo(
+                                        f" {wrn} See container error details:{os.linesep}{os.linesep}{msg}"
+                                    )
                                     routes_error = True
                     if routes_error:
                         break
@@ -254,20 +306,32 @@ class PRAXClient:
             for stage in project.stages:
                 for route in stage.resources.routes:
                     urls = [f"https://{d}" for d in route.custom_domains] + [route.url]
-                    if route.next_revision_status and str(route.next_revision_status) in ['error']:
-                        click.echo(f" {err} Route '{route.name}' at revision #{project.last_revision.number} failed to start!")
+                    if route.next_revision_status and str(
+                        route.next_revision_status
+                    ) in ["error"]:
+                        click.echo(
+                            f" {err} Route '{route.name}' at revision #{project.last_revision.number} failed to start!"
+                        )
                         if route.details:
-                            msg = route.details.get('message', 'No error message provided')
+                            msg = route.details.get(
+                                "message", "No error message provided"
+                            )
                         else:
-                            msg = 'No error details provided'
-                        click.echo(f" {wrn} Error details:{os.linesep}{os.linesep}{msg}")
-                    if route.status in ['online', 'offline']:
-                        s = 's' if len(urls) > 1 else ''
-                        click.echo(f" {chk} Route '{route.name}' is {_frs(route.status)} and available at URL{s}:")
+                            msg = "No error details provided"
+                        click.echo(
+                            f" {wrn} Error details:{os.linesep}{os.linesep}{msg}"
+                        )
+                    if route.status in ["online", "offline"]:
+                        s = "s" if len(urls) > 1 else ""
+                        click.echo(
+                            f" {chk} Route '{route.name}' is {_frs(route.status)} and available at URL{s}:"
+                        )
                         for url in urls:
                             click.echo(f" {globe} {url}")
-        
-    def _handle_errors(self, response: requests.Response) -> models.ErrorResponse|None:
+
+    def _handle_errors(
+        self, response: requests.Response
+    ) -> models.ErrorResponse | None:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError:
@@ -283,24 +347,27 @@ class PRAXClient:
             return models.ErrorResponse(detail=str(e))
         except Exception as e:
             return models.ErrorResponse(detail=str(e))
-        
-    
-    def _run_action(self, 
-            action: Literal['submit', 'terminate', 'retry'],
-            endpoint: Literal['task', 'pipeline', 'build','task-runs','pipeline-runs','build-runs'],
-            run_name: str,
-        **params) -> models.StagedRunSchema | models.ErrorResponse:
+
+    def _run_action(
+        self,
+        action: Literal["submit", "terminate", "retry"],
+        endpoint: Literal[
+            "task", "pipeline", "build", "task-runs", "pipeline-runs", "build-runs"
+        ],
+        run_name: str,
+        **params,
+    ) -> models.StagedRunSchema | models.ErrorResponse:
         confirm_status = {
-            'submit': 'Pending',
-            'terminate': 'Failed',
-            'retry': ['Pending', 'Running', 'Failed', 'Error']
+            "submit": "Pending",
+            "terminate": "Failed",
+            "retry": ["Pending", "Running", "Failed", "Error"],
         }
         obj, errs = self._request(
-            'PUT' if action in ['terminate', 'retry'] else 'POST',
-            f'{endpoint}/{run_name}/{action}', 
-            json=params or None, 
+            "PUT" if action in ["terminate", "retry"] else "POST",
+            f"{endpoint}/{run_name}/{action}",
+            json=params or None,
             params=params or None,
-            schema=models.StagedRunSchema
+            schema=models.StagedRunSchema,
         )
         if errs:
             return errs
@@ -308,21 +375,33 @@ class PRAXClient:
             if obj.status in confirm_status[action]:
                 return obj
             else:
-                return models.ErrorResponse(detail=f"Failed to {action} run '{run_name}'!")
+                return models.ErrorResponse(
+                    detail=f"Failed to {action} run '{run_name}'!"
+                )
         else:
             return models.ErrorResponse(detail=f"Failed to {action} run '{run_name}'!")
-        
-    def _submit(self, 
-            resp_model: Type[models.TaskSchema|models.BuildSchema|models.PipelineSchema],
-            name: str, 
-            parameters: dict|None, 
-            **filters) -> models.TaskSchema | models.BuildSchema | models.PipelineSchema | models.ErrorResponse:
-        endpoint = resp_model.__name__.removesuffix('Schema').lower()+"s"
-        obj, errs = self._request('POST',
-            f'{endpoint}/{name}/submit', 
-            json={'parameters': parameters} if parameters else None, 
+
+    def _submit(
+        self,
+        resp_model: Type[
+            models.TaskSchema | models.BuildSchema | models.PipelineSchema
+        ],
+        name: str,
+        parameters: dict | None,
+        **filters,
+    ) -> (
+        models.TaskSchema
+        | models.BuildSchema
+        | models.PipelineSchema
+        | models.ErrorResponse
+    ):
+        endpoint = resp_model.__name__.removesuffix("Schema").lower() + "s"
+        obj, errs = self._request(
+            "POST",
+            f"{endpoint}/{name}/submit",
+            json={"parameters": parameters} if parameters else None,
             params=filters or None,
-            schema=resp_model
+            schema=resp_model,
         )
         if isinstance(obj, resp_model):
             return obj
@@ -330,10 +409,9 @@ class PRAXClient:
             return errs
         else:
             return models.ErrorResponse(detail=f"Failed to submit {endpoint} '{name}'!")
-    
-    def _validate_schema(self, 
-        response: requests.Response, 
-        schema: Type[Any]
+
+    def _validate_schema(
+        self, response: requests.Response, schema: Type[Any]
     ) -> Any | models.ErrorResponse:
         try:
             json_data = response.json()
@@ -348,16 +426,20 @@ class PRAXClient:
             return models.ErrorResponse(detail=response.text)
         except ValidationError as e:
             click.echo(f" {err} API Validation Error")
-            click.echo(f" {wrn} This may be due to an outdated version of the client library, {os.linesep}"
-                       "please try update with \"pip install -U oceanum-prax\" and try again!")
+            click.echo(
+                f" {wrn} This may be due to an outdated version of the client library, {os.linesep}"
+                'please try update with "pip install -U oceanum-prax" and try again!'
+            )
             if self.ctx:
                 self.ctx.exit(1)
-            return models.ErrorResponse(detail=[
-                models.ValidationErrorDetail(
-                    loc=[str(v) for v in e['loc']], 
-                    msg=e['msg'], 
-                    type=e['type']) for e in e.errors()
-                ])
+            return models.ErrorResponse(
+                detail=[
+                    models.ValidationErrorDetail(
+                        loc=[str(v) for v in e["loc"]], msg=e["msg"], type=e["type"]
+                    )
+                    for e in e.errors()
+                ]
+            )
 
     def wait_project_deployment(self, **params) -> bool:
         self._deploy_start_time = time.time()
@@ -368,12 +450,12 @@ class PRAXClient:
             if build_succeeded:
                 self._wait_stages_finish_updating(**params)
                 self._check_routes(**params)
-            delta = timedelta(seconds=time.time()-self._deploy_start_time)
+            delta = timedelta(seconds=time.time() - self._deploy_start_time)
             click.echo(f" {watch} Deployment finished {humanize.naturaldelta(delta)}.")
         return True
-    
+
     @classmethod
-    def load_spec(cls, specfile: str) -> models.ProjectSpec|models.ErrorResponse:
+    def load_spec(cls, specfile: str) -> models.ProjectSpec | models.ErrorResponse:
         try:
             with Path(specfile).open() as f:
                 spec_dict = yaml.safe_load(f)
@@ -381,86 +463,139 @@ class PRAXClient:
         except FileNotFoundError:
             return models.ErrorResponse(detail=f"Specfile not found: {specfile}")
         except ValidationError as e:
-            return models.ErrorResponse(detail=[
-                models.ValidationErrorDetail(
-                    loc=[str(v) for v in e['loc']], 
-                    msg=e['msg'], 
-                    type=e['type']) for e in e.errors()
-                ])
-    
-    def list_projects(self, **filters) -> list[models.ProjectItemSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'projects', params=filters or None, schema=models.ProjectItemSchema)
+            return models.ErrorResponse(
+                detail=[
+                    models.ValidationErrorDetail(
+                        loc=[str(v) for v in e["loc"]], msg=e["msg"], type=e["type"]
+                    )
+                    for e in e.errors()
+                ]
+            )
+
+    def list_projects(
+        self, **filters
+    ) -> list[models.ProjectItemSchema] | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET", "projects", params=filters or None, schema=models.ProjectItemSchema
+        )
         list_projects_err = models.ErrorResponse(detail="Failed to list projects!")
-        return obj if isinstance(obj, list) else errs or list_projects_err        
-    
-    def get_project(self, project_name: str, **filters) -> models.ProjectDetailsSchema|models.ErrorResponse:
+        return obj if isinstance(obj, list) else errs or list_projects_err
+
+    def get_project(
+        self, project_name: str, **filters
+    ) -> models.ProjectDetailsSchema | models.ErrorResponse:
         """
         Try to get a project by name and org/user filters,
         when the project is not found, print the error message and return None
         """
-        obj, errs = self._request('GET', f'projects/{project_name}', 
-                                  params=filters or None, schema=models.ProjectDetailsSchema)
-        get_project_err = models.ErrorResponse(detail=f"Failed to get project '{project_name}'!")
-        return obj if isinstance(obj, models.ProjectDetailsSchema) else errs or get_project_err
-    
-    def deploy_project(self, spec: models.ProjectSpec) -> models.ProjectDetailsSchema | models.ErrorResponse:
-        payload = dump_with_secrets(spec)
-        obj, errs = self._request('POST', 'projects', json=payload, schema=models.ProjectDetailsSchema)
-        deploy_err = models.ErrorResponse(detail="Failed to deploy project!")
-        return obj if isinstance(obj, models.ProjectDetailsSchema) else errs or deploy_err
+        obj, errs = self._request(
+            "GET",
+            f"projects/{project_name}",
+            params=filters or None,
+            schema=models.ProjectDetailsSchema,
+        )
+        get_project_err = models.ErrorResponse(
+            detail=f"Failed to get project '{project_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.ProjectDetailsSchema)
+            else errs or get_project_err
+        )
 
-    def patch_project(self, project_name: str, ops: list[models.JSONPatchOpSchema]) -> models.ProjectDetailsSchema | models.ErrorResponse:
-        payload = [op.model_dump(exclude_none=True, mode='json') for op in ops]
-        obj, errs = self._request('PATCH', f'projects/{project_name}', json=payload, schema=models.ProjectDetailsSchema)
+    def deploy_project(
+        self, spec: models.ProjectSpec
+    ) -> models.ProjectDetailsSchema | models.ErrorResponse:
+        payload = dump_with_secrets(spec)
+        obj, errs = self._request(
+            "POST", "projects", json=payload, schema=models.ProjectDetailsSchema
+        )
+        deploy_err = models.ErrorResponse(detail="Failed to deploy project!")
+        return (
+            obj if isinstance(obj, models.ProjectDetailsSchema) else errs or deploy_err
+        )
+
+    def patch_project(
+        self, project_name: str, ops: list[models.JSONPatchOpSchema]
+    ) -> models.ProjectDetailsSchema | models.ErrorResponse:
+        payload = [op.model_dump(exclude_none=True, mode="json") for op in ops]
+        obj, errs = self._request(
+            "PATCH",
+            f"projects/{project_name}",
+            json=payload,
+            schema=models.ProjectDetailsSchema,
+        )
         patch_err = models.ErrorResponse(detail="Failed to patch project!")
-        return obj if isinstance(obj, models.ProjectDetailsSchema) else errs or patch_err
-    
+        return (
+            obj if isinstance(obj, models.ProjectDetailsSchema) else errs or patch_err
+        )
+
     def delete_project(self, project_id: str, **filters) -> str | models.ErrorResponse:
-        _, errs = self._request('DELETE', f'projects/{project_id}', params=filters or None)
+        _, errs = self._request(
+            "DELETE", f"projects/{project_id}", params=filters or None
+        )
         return errs if errs else "Project deleted successfully!"
-    
+
     # USER METHODS
-    
+
     def get_users(self) -> list[models.UserSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'users', schema=models.UserSchema, params=None)
+        obj, errs = self._request("GET", "users", schema=models.UserSchema, params=None)
         get_users_err = models.ErrorResponse(detail="Failed to get users!")
         return obj if isinstance(obj, list) else errs or get_users_err
-    
+
     def get_org(self, org: str) -> models.OrgDetailsSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'orgs/{org}', schema=models.OrgDetailsSchema, params=None)
+        obj, errs = self._request(
+            "GET", f"orgs/{org}", schema=models.OrgDetailsSchema, params=None
+        )
         get_org_err = models.ErrorResponse(detail="Failed to get organization details!")
         return obj if isinstance(obj, models.OrgDetailsSchema) else errs or get_org_err
-    
-    def create_or_update_user_secret(self, secret_name: str, org: str, secret_data: dict, description: str|None = None) -> models.SecretSpec | models.ErrorResponse:
-        obj, errs = self._request('POST',
-            f'orgs/{org}/resources/secrets', 
-            json={
-                'name': secret_name, 
-                'description': description,
-                'data': secret_data
-            },
-            schema=models.SecretSpec
+
+    def create_or_update_user_secret(
+        self,
+        secret_name: str,
+        org: str,
+        secret_data: dict,
+        description: str | None = None,
+    ) -> models.SecretSpec | models.ErrorResponse:
+        obj, errs = self._request(
+            "POST",
+            f"orgs/{org}/resources/secrets",
+            json={"name": secret_name, "description": description, "data": secret_data},
+            schema=models.SecretSpec,
         )
-        secret_err = models.ErrorResponse(detail="Failed to create or update user secret!")
+        secret_err = models.ErrorResponse(
+            detail="Failed to create or update user secret!"
+        )
         return obj if isinstance(obj, models.SecretSpec) else errs or secret_err
 
-
-    def list_sources(self, **filters) -> list[models.SourceSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'sources', params=filters or None, schema=models.SourceSchema)
+    def list_sources(
+        self, **filters
+    ) -> list[models.SourceSchema] | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET", "sources", params=filters or None, schema=models.SourceSchema
+        )
         list_sources_err = models.ErrorResponse(detail="Failed to list sources!")
         return obj if isinstance(obj, list) else errs or list_sources_err
-    
+
     def list_tasks(self, **filters) -> list[models.TaskSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'tasks', params=filters or None, schema=models.TaskSchema)
+        obj, errs = self._request(
+            "GET", "tasks", params=filters or None, schema=models.TaskSchema
+        )
         list_tasks_err = models.ErrorResponse(detail="Failed to list tasks!")
         return obj if isinstance(obj, list) else errs or list_tasks_err
-        
-    def get_task(self, task_id: str, **filters) -> models.TaskSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'tasks/{task_id}', params=filters or None, schema=models.TaskSchema)
+
+    def get_task(
+        self, task_id: str, **filters
+    ) -> models.TaskSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET", f"tasks/{task_id}", params=filters or None, schema=models.TaskSchema
+        )
         get_task_err = models.ErrorResponse(detail=f"Failed to get task '{task_id}'!")
         return obj if isinstance(obj, models.TaskSchema) else errs or get_task_err
-    
-    def submit_task(self, task_name: str, parameters: dict|None, **filters) -> models.TaskSchema | models.ErrorResponse:
+
+    def submit_task(
+        self, task_name: str, parameters: dict | None, **filters
+    ) -> models.TaskSchema | models.ErrorResponse:
         task = self._submit(models.TaskSchema, task_name, parameters, **filters)
         if isinstance(task, models.TaskSchema):
             return task
@@ -468,85 +603,225 @@ class PRAXClient:
             return task
         else:
             return models.ErrorResponse(detail="Failed to submit task!")
-    
-    def get_task_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'task-runs/{run_name}', params=filters or None, schema=models.StagedRunSchema)
-        get_task_run_err = models.ErrorResponse(detail=f"Failed to get task run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or get_task_run_err
-    
-    def terminate_task_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'task-runs/{run_name}/terminate', params=filters or None, schema=models.StagedRunSchema)
-        terminate_task_run_err = models.ErrorResponse(detail=f"Failed to terminate task run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or terminate_task_run_err
-    
-    def retry_task_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'task-runs/{run_name}/retry', params=filters or None, schema=models.StagedRunSchema)
-        retry_task_run_err = models.ErrorResponse(detail=f"Failed to retry task run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or retry_task_run_err
+
+    def get_task_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET",
+            f"task-runs/{run_name}",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        get_task_run_err = models.ErrorResponse(
+            detail=f"Failed to get task run '{run_name}'!"
+        )
+        return (
+            obj if isinstance(obj, models.StagedRunSchema) else errs or get_task_run_err
+        )
+
+    def terminate_task_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"task-runs/{run_name}/terminate",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        terminate_task_run_err = models.ErrorResponse(
+            detail=f"Failed to terminate task run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or terminate_task_run_err
+        )
+
+    def retry_task_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"task-runs/{run_name}/retry",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        retry_task_run_err = models.ErrorResponse(
+            detail=f"Failed to retry task run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or retry_task_run_err
+        )
 
     def delete_task_run(self, run_name: str, **filters) -> str | models.ErrorResponse:
-        _, errs = self._request('DELETE', f'task-runs/{run_name}', params=filters or None)
+        _, errs = self._request(
+            "DELETE", f"task-runs/{run_name}", params=filters or None
+        )
         return errs if errs else "Task run deleted successfully!"
-    
-    def list_pipelines(self, **filters) -> list[models.PipelineSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'pipelines', params=filters or None, schema=models.PipelineSchema)
+
+    def list_pipelines(
+        self, **filters
+    ) -> list[models.PipelineSchema] | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET", "pipelines", params=filters or None, schema=models.PipelineSchema
+        )
         list_pipelines_err = models.ErrorResponse(detail="Failed to list pipelines!")
         return obj if isinstance(obj, list) else errs or list_pipelines_err
-        
-    def get_pipeline(self, pipeline_name: str, **filters) -> models.PipelineSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'pipelines/{pipeline_name}', params=filters or None, schema=models.PipelineSchema)
-        get_pipeline_err = models.ErrorResponse(detail=f"Failed to get pipeline '{pipeline_name}'!")
-        return obj if isinstance(obj, models.PipelineSchema) else errs or get_pipeline_err
-    
-    def submit_pipeline(self, pipeline_name: str, parameters: dict|None=None, **filters) -> models.PipelineSchema | models.ErrorResponse:
-        pipeline = self._submit(models.PipelineSchema, pipeline_name, parameters, **filters)
+
+    def get_pipeline(
+        self, pipeline_name: str, **filters
+    ) -> models.PipelineSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET",
+            f"pipelines/{pipeline_name}",
+            params=filters or None,
+            schema=models.PipelineSchema,
+        )
+        get_pipeline_err = models.ErrorResponse(
+            detail=f"Failed to get pipeline '{pipeline_name}'!"
+        )
+        return (
+            obj if isinstance(obj, models.PipelineSchema) else errs or get_pipeline_err
+        )
+
+    def submit_pipeline(
+        self, pipeline_name: str, parameters: dict | None = None, **filters
+    ) -> models.PipelineSchema | models.ErrorResponse:
+        pipeline = self._submit(
+            models.PipelineSchema, pipeline_name, parameters, **filters
+        )
         if isinstance(pipeline, models.PipelineSchema):
             return pipeline
         elif isinstance(pipeline, models.ErrorResponse):
             return pipeline
         else:
             return models.ErrorResponse(detail="Failed to submit pipeline!")
-    
-    def get_pipeline_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'pipeline-runs/{run_name}', params=filters or None, schema=models.StagedRunSchema)
-        get_pipeline_run_err = models.ErrorResponse(detail=f"Failed to get pipeline run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or get_pipeline_run_err
-    
-    def terminate_pipeline_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'pipeline-runs/{run_name}/terminate', params=filters or None, schema=models.StagedRunSchema)
-        terminate_pipeline_run_err = models.ErrorResponse(detail=f"Failed to terminate pipeline run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or terminate_pipeline_run_err
-    
-    def stop_pipeline_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'pipeline-runs/{run_name}/stop', params=filters or None, schema=models.StagedRunSchema)
-        stop_pipeline_run_err = models.ErrorResponse(detail=f"Failed to stop pipeline run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or stop_pipeline_run_err
-    
-    def resume_pipeline_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'pipeline-runs/{run_name}/resume', params=filters or None, schema=models.StagedRunSchema)
-        resume_pipeline_run_err = models.ErrorResponse(detail=f"Failed to resume pipeline run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or resume_pipeline_run_err
-    
-    def retry_pipeline_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'pipeline-runs/{run_name}/retry', params=filters or None, schema=models.StagedRunSchema)
-        retry_pipeline_run_err = models.ErrorResponse(detail=f"Failed to retry pipeline run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or retry_pipeline_run_err
-    
-    def delete_pipeline_run(self, run_name: str, **filters) -> str | models.ErrorResponse:
-        _, errs = self._request('DELETE', f'pipeline-runs/{run_name}', params=filters or None)
+
+    def get_pipeline_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET",
+            f"pipeline-runs/{run_name}",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        get_pipeline_run_err = models.ErrorResponse(
+            detail=f"Failed to get pipeline run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or get_pipeline_run_err
+        )
+
+    def terminate_pipeline_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"pipeline-runs/{run_name}/terminate",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        terminate_pipeline_run_err = models.ErrorResponse(
+            detail=f"Failed to terminate pipeline run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or terminate_pipeline_run_err
+        )
+
+    def stop_pipeline_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"pipeline-runs/{run_name}/stop",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        stop_pipeline_run_err = models.ErrorResponse(
+            detail=f"Failed to stop pipeline run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or stop_pipeline_run_err
+        )
+
+    def resume_pipeline_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"pipeline-runs/{run_name}/resume",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        resume_pipeline_run_err = models.ErrorResponse(
+            detail=f"Failed to resume pipeline run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or resume_pipeline_run_err
+        )
+
+    def retry_pipeline_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"pipeline-runs/{run_name}/retry",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        retry_pipeline_run_err = models.ErrorResponse(
+            detail=f"Failed to retry pipeline run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or retry_pipeline_run_err
+        )
+
+    def delete_pipeline_run(
+        self, run_name: str, **filters
+    ) -> str | models.ErrorResponse:
+        _, errs = self._request(
+            "DELETE", f"pipeline-runs/{run_name}", params=filters or None
+        )
         return errs if errs else "Pipeline run deleted successfully!"
 
     def list_builds(self, **filters) -> list[models.BuildSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'builds', params=filters or None, schema=models.BuildSchema)
+        obj, errs = self._request(
+            "GET", "builds", params=filters or None, schema=models.BuildSchema
+        )
         list_builds_err = models.ErrorResponse(detail="Failed to list builds!")
         return obj if isinstance(obj, list) else errs or list_builds_err
-    
-    def get_build(self, build_name: str, **filters) -> models.BuildSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'builds/{build_name}', params=filters or None, schema=models.BuildSchema)
-        get_build_err = models.ErrorResponse(detail=f"Failed to get build '{build_name}'!")
+
+    def get_build(
+        self, build_name: str, **filters
+    ) -> models.BuildSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET",
+            f"builds/{build_name}",
+            params=filters or None,
+            schema=models.BuildSchema,
+        )
+        get_build_err = models.ErrorResponse(
+            detail=f"Failed to get build '{build_name}'!"
+        )
         return obj if isinstance(obj, models.BuildSchema) else errs or get_build_err
-    
-    def submit_build(self, build_name: str, parameters: dict|None=None,  **filters) -> models.BuildSchema | models.ErrorResponse:
+
+    def submit_build(
+        self, build_name: str, parameters: dict | None = None, **filters
+    ) -> models.BuildSchema | models.ErrorResponse:
         build = self._submit(models.BuildSchema, build_name, parameters, **filters)
         if isinstance(build, models.BuildSchema):
             return build
@@ -554,91 +829,141 @@ class PRAXClient:
             return build
         else:
             return models.ErrorResponse(detail="Failed to submit build!")
-    
-    def get_build_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'build-runs/{run_name}', params=filters or None, 
-                                  schema=models.StagedRunSchema)
-        get_build_run_err = models.ErrorResponse(detail=f"Failed to get build run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or get_build_run_err
-    
-    def terminate_build_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'build-runs/{run_name}/terminate', params=filters or None, 
-                                  scheuma=models.StagedRunSchema)
-        terminate_build_run_err = models.ErrorResponse(detail=f"Failed to terminate build run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or terminate_build_run_err
-    
-    def retry_build_run(self, run_name: str, **filters) -> models.StagedRunSchema | models.ErrorResponse:
-        obj, errs = self._request('PUT', f'build-runs/{run_name}/retry', params=filters or None, 
-                                  schema=models.StagedRunSchema)
-        retry_build_run_err = models.ErrorResponse(detail=f"Failed to retry build run '{run_name}'!")
-        return obj if isinstance(obj, models.StagedRunSchema) else errs or retry_build_run_err
-    
+
+    def get_build_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "GET",
+            f"build-runs/{run_name}",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        get_build_run_err = models.ErrorResponse(
+            detail=f"Failed to get build run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or get_build_run_err
+        )
+
+    def terminate_build_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"build-runs/{run_name}/terminate",
+            params=filters or None,
+            scheuma=models.StagedRunSchema,
+        )
+        terminate_build_run_err = models.ErrorResponse(
+            detail=f"Failed to terminate build run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or terminate_build_run_err
+        )
+
+    def retry_build_run(
+        self, run_name: str, **filters
+    ) -> models.StagedRunSchema | models.ErrorResponse:
+        obj, errs = self._request(
+            "PUT",
+            f"build-runs/{run_name}/retry",
+            params=filters or None,
+            schema=models.StagedRunSchema,
+        )
+        retry_build_run_err = models.ErrorResponse(
+            detail=f"Failed to retry build run '{run_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.StagedRunSchema)
+            else errs or retry_build_run_err
+        )
+
     def delete_build_run(self, run_name: str, **filters) -> str | models.ErrorResponse:
-        _, errs = self._request('DELETE', f'build-runs/{run_name}', params=filters or None)
+        _, errs = self._request(
+            "DELETE", f"build-runs/{run_name}", params=filters or None
+        )
         return errs if errs else "Build run deleted successfully!"
-    
+
     def list_routes(self, **filters) -> list[models.RouteSchema] | models.ErrorResponse:
-        obj, errs = self._request('GET', 'routes', params=filters or None, 
-                                  schema=models.RouteSchema)
+        obj, errs = self._request(
+            "GET", "routes", params=filters or None, schema=models.RouteSchema
+        )
         list_routes_err = models.ErrorResponse(detail="Failed to list routes!")
         return obj if isinstance(obj, list) else errs or list_routes_err
-    
+
     def get_route(self, route_name: str) -> models.RouteSchema | models.ErrorResponse:
-        obj, errs = self._request('GET', f'routes/{route_name}', 
-                                  schema=models.RouteSchema)
-        get_route_err = models.ErrorResponse(detail=f"Failed to get route '{route_name}'!")
+        obj, errs = self._request(
+            "GET", f"routes/{route_name}", schema=models.RouteSchema
+        )
+        get_route_err = models.ErrorResponse(
+            detail=f"Failed to get route '{route_name}'!"
+        )
         return obj if isinstance(obj, models.RouteSchema) else errs or get_route_err
-    
-    def _download_artifact(self, 
-        resource_type: Literal['task','pipeline'],
+
+    def _download_artifact(
+        self,
+        resource_type: Literal["task", "pipeline"],
         resource_name: str,
         artifact_name: str,
-        step_name: str|None = None,
-        output_path: str|None = None,
-        #force: bool = False,
+        step_name: str | None = None,
+        output_path: str | None = None,
+        # force: bool = False,
     ) -> bool:
-        if resource_type == 'pipeline' and step_name is None:
-            click.echo(f" {err} 'step_name' is required to download artifact from pipeline runs!")
+        if resource_type == "pipeline" and step_name is None:
+            click.echo(
+                f" {err} 'step_name' is required to download artifact from pipeline runs!"
+            )
             return False
-        elif resource_type == 'pipeline' and step_name is not None:
-            url = f'pipeline-runs/{resource_name}/artifacts/{step_name}/{artifact_name}'
+        elif resource_type == "pipeline" and step_name is not None:
+            url = f"pipeline-runs/{resource_name}/artifacts/{step_name}/{artifact_name}"
         else:
-            url = f'task-runs/{resource_name}/artifacts/{artifact_name}'
+            url = f"task-runs/{resource_name}/artifacts/{artifact_name}"
         if output_path is not None:
             output_dir = Path(output_path).parent
             output_file = Path(output_path).name
             artifact_path = output_dir / output_file
         else:
             output_dir = Path(os.getcwd())
-            output_file = f'{artifact_name}.gz'
+            output_file = f"{artifact_name}.gz"
             artifact_path = output_dir / output_file
-        click.echo(f" {spin} Downloading artifact '{artifact_name}' from {resource_type.title()}-Run '{resource_name}' to '{output_file}' file...")
-        response, errs = self._request('GET', url, schema=None, stream=True)
+        click.echo(
+            f" {spin} Downloading artifact '{artifact_name}' from {resource_type.title()}-Run '{resource_name}' to '{output_file}' file..."
+        )
+        response, errs = self._request("GET", url, schema=None, stream=True)
         if errs:
-            click.echo(f" {err} Failed to download artifact '{artifact_name}' from {resource_type} '{resource_name}'!")
+            click.echo(
+                f" {err} Failed to download artifact '{artifact_name}' from {resource_type} '{resource_name}'!"
+            )
             click.echo(f" {wrn} {errs.detail}")
             return False
         elif isinstance(response, requests.Response) and response.ok:
-            with open(artifact_path, 'w+b') as f:
+            with open(artifact_path, "w+b") as f:
                 for chunk in response.raw.stream(1024, decode_content=False):
                     f.write(chunk)
             return True
-        click.echo(f" {err} Failed to download artifact '{artifact_name}' from {resource_type} '{resource_name}'!")
+        click.echo(
+            f" {err} Failed to download artifact '{artifact_name}' from {resource_type} '{resource_name}'!"
+        )
         return False
-    
-    def _get_logs(self, 
-        run_name: str, 
-        lines: int, 
-        follow: bool, 
-        endpoint: Literal['task-runs', 'pipeline-runs', 'build-runs', 'routes'],
-        **filters
-    ) -> Iterable[str|models.ErrorResponse]:
-        filters['follow'] = follow
-        filters['tail'] = lines
-        response, errs = self._request('GET', 
-            f'{endpoint}/{run_name}/logs', 
-            params=filters or None,
-            stream=True
+
+    def _get_logs(
+        self,
+        run_name: str,
+        lines: int,
+        follow: bool,
+        endpoint: Literal["task-runs", "pipeline-runs", "build-runs", "routes"],
+        **filters,
+    ) -> Iterable[str | models.ErrorResponse]:
+        filters["follow"] = follow
+        filters["tail"] = lines
+        response, errs = self._request(
+            "GET", f"{endpoint}/{run_name}/logs", params=filters or None, stream=True
         )
         if isinstance(response, requests.Response) and response.ok:
             for line in response.iter_lines():
@@ -646,113 +971,145 @@ class PRAXClient:
         else:
             yield errs if errs else models.ErrorResponse(detail=response.text)
 
-    def download_task_run_artifact(self, 
-        task_run_name: str, 
-        artifact_name: str, 
-        output_path: str|None = None
+    def download_task_run_artifact(
+        self, task_run_name: str, artifact_name: str, output_path: str | None = None
     ) -> bool:
         return self._download_artifact(
-            resource_type='task',
+            resource_type="task",
             resource_name=task_run_name,
             artifact_name=artifact_name,
             output_path=output_path,
         )
 
-    def download_pipeline_run_artifact(self,
-        pipeline_run_name: str, 
-        artifact_name: str, 
+    def download_pipeline_run_artifact(
+        self,
+        pipeline_run_name: str,
+        artifact_name: str,
         step_name: str,
-        output_path: str|None = None
+        output_path: str | None = None,
     ) -> bool:
         return self._download_artifact(
-            resource_type='pipeline',
+            resource_type="pipeline",
             resource_name=pipeline_run_name,
             artifact_name=artifact_name,
             step_name=step_name,
             output_path=output_path,
         )
-    
-    def get_build_run_logs(self, run_name: str, lines: int, follow: bool, **filters) -> Iterable[str|models.ErrorResponse]:
+
+    def get_build_run_logs(
+        self, run_name: str, lines: int, follow: bool, **filters
+    ) -> Iterable[str | models.ErrorResponse]:
         yield from self._get_logs(
-            run_name=run_name, 
-            lines=lines, 
-            follow=follow, 
-            endpoint='build-runs', 
-            **filters
+            run_name=run_name,
+            lines=lines,
+            follow=follow,
+            endpoint="build-runs",
+            **filters,
         )
 
-    def get_task_run_logs(self, run_name: str, lines: int, follow: bool, **filters) -> Iterable[str|models.ErrorResponse]:
+    def get_task_run_logs(
+        self, run_name: str, lines: int, follow: bool, **filters
+    ) -> Iterable[str | models.ErrorResponse]:
         yield from self._get_logs(
-            run_name=run_name, 
-            lines=lines, 
-            follow=follow, 
-            endpoint='task-runs', 
-            **filters
+            run_name=run_name,
+            lines=lines,
+            follow=follow,
+            endpoint="task-runs",
+            **filters,
         )
 
-    def get_pipeline_run_logs(self, run_name: str, lines: int, follow: bool, **filters) -> Iterable[str|models.ErrorResponse]:
+    def get_pipeline_run_logs(
+        self, run_name: str, lines: int, follow: bool, **filters
+    ) -> Iterable[str | models.ErrorResponse]:
         yield from self._get_logs(
-            run_name=run_name, 
-            lines=lines, 
-            follow=follow, 
-            endpoint='pipeline-runs', 
-            **filters
+            run_name=run_name,
+            lines=lines,
+            follow=follow,
+            endpoint="pipeline-runs",
+            **filters,
         )
-    
-    def get_route_logs(self, route_name: str, lines: int, follow: bool, **filters) -> Iterable[str|models.ErrorResponse]:
+
+    def get_route_logs(
+        self, route_name: str, lines: int, follow: bool, **filters
+    ) -> Iterable[str | models.ErrorResponse]:
         yield from self._get_logs(
-            run_name=route_name, 
-            lines=lines, 
-            follow=follow, 
-            endpoint='routes', 
-            **filters
+            run_name=route_name,
+            lines=lines,
+            follow=follow,
+            endpoint="routes",
+            **filters,
         )
-            
-    def update_route_thumbnail(self, route_name: str, thumbnail: click.File) -> models.RouteSchema | models.ErrorResponse:
-        files = {'thumbnail': thumbnail}
-        obj, errs = self._request('POST',f'routes/{route_name}/thumbnail', files=files, schema=models.RouteSchema)
-        update_route_thumbnail_err = models.ErrorResponse(detail=f"Failed to update route '{route_name}' thumbnail!")
-        return obj if isinstance(obj, models.RouteSchema) else errs or update_route_thumbnail_err
-    
+
+    def update_route_thumbnail(
+        self, route_name: str, thumbnail: click.File
+    ) -> models.RouteSchema | models.ErrorResponse:
+        files = {"thumbnail": thumbnail}
+        obj, errs = self._request(
+            "POST",
+            f"routes/{route_name}/thumbnail",
+            files=files,
+            schema=models.RouteSchema,
+        )
+        update_route_thumbnail_err = models.ErrorResponse(
+            detail=f"Failed to update route '{route_name}' thumbnail!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.RouteSchema)
+            else errs or update_route_thumbnail_err
+        )
+
     def validate(self, specfile: str) -> models.ProjectSpec | models.ErrorResponse:
         resp = self.load_spec(specfile)
         if isinstance(resp, models.ErrorResponse):
             return resp
         else:
             spec_dict = resp.model_dump(
-                exclude_none=True,
-                exclude_unset=True,
-                by_alias=True,
-                mode='json'
+                exclude_none=True, exclude_unset=True, by_alias=True, mode="json"
             )
-            obj, errs = self._request('POST','validate', json=spec_dict, schema=models.ProjectSpec)
+            obj, errs = self._request(
+                "POST", "validate", json=spec_dict, schema=models.ProjectSpec
+            )
             err = models.ErrorResponse(detail="Failed to validate project spec!")
             return obj if isinstance(obj, models.ProjectSpec) else errs or err
-        
-    def allow_project(self, 
-        project_name: str, 
-        permissions: models.ResourcePermissionsSchema, 
-        **filters
+
+    def allow_project(
+        self,
+        project_name: str,
+        permissions: models.ResourcePermissionsSchema,
+        **filters,
     ) -> models.ResourcePermissionsSchema | models.ErrorResponse:
-        obj, errs = self._request('POST',
-            f'projects/{project_name}/permissions',
-            params=filters or None, 
+        obj, errs = self._request(
+            "POST",
+            f"projects/{project_name}/permissions",
+            params=filters or None,
             json=permissions.model_dump(),
-            schema=models.ResourcePermissionsSchema
+            schema=models.ResourcePermissionsSchema,
         )
-        allow_project_err = models.ErrorResponse(detail=f"Failed to allow project '{project_name}'!")
-        return obj if isinstance(obj, models.ResourcePermissionsSchema) else errs or allow_project_err
-    
-    def allow_route(self, 
-        route_name: str, 
-        permissions: models.ResourcePermissionsSchema, 
-        **filters
+        allow_project_err = models.ErrorResponse(
+            detail=f"Failed to allow project '{project_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.ResourcePermissionsSchema)
+            else errs or allow_project_err
+        )
+
+    def allow_route(
+        self, route_name: str, permissions: models.ResourcePermissionsSchema, **filters
     ) -> models.ResourcePermissionsSchema | models.ErrorResponse:
-        obj, errs = self._request('POST',
-            f'routes/{route_name}/permissions',
-            params=filters or None, 
+        obj, errs = self._request(
+            "POST",
+            f"routes/{route_name}/permissions",
+            params=filters or None,
             json=permissions.model_dump(),
-            schema=models.ResourcePermissionsSchema
+            schema=models.ResourcePermissionsSchema,
         )
-        allow_route_err = models.ErrorResponse(detail=f"Failed to allow route '{route_name}'!")
-        return obj if isinstance(obj, models.ResourcePermissionsSchema) else errs or allow_route_err
+        allow_route_err = models.ErrorResponse(
+            detail=f"Failed to allow route '{route_name}'!"
+        )
+        return (
+            obj
+            if isinstance(obj, models.ResourcePermissionsSchema)
+            else errs or allow_route_err
+        )

--- a/src/oceanum/cli/prax/client.py
+++ b/src/oceanum/cli/prax/client.py
@@ -855,7 +855,7 @@ class PRAXClient:
             "PUT",
             f"build-runs/{run_name}/terminate",
             params=filters or None,
-            scheuma=models.StagedRunSchema,
+            schema=models.StagedRunSchema,
         )
         terminate_build_run_err = models.ErrorResponse(
             detail=f"Failed to terminate build run '{run_name}'!"

--- a/src/oceanum/cli/prax/client.py
+++ b/src/oceanum/cli/prax/client.py
@@ -177,13 +177,12 @@ class PRAXClient:
                     break
                 else:
                     click.echo(f" {spin} Waiting for project to start updating...")
-                    pass
                     time.sleep(self._lag)
                     counter += 1
-                return project
             else:
                 click.echo(f" {err} Failed to get project details!")
                 break
+        return project
 
     def _wait_builds_to_finish(self, **params):
         def get_builds(project) -> list[models.BuildSchema]:

--- a/src/oceanum/cli/prax/main.py
+++ b/src/oceanum/cli/prax/main.py
@@ -1,57 +1,71 @@
 from oceanum.cli import main
 
-@main.group(name='prax', help='Oceanum PRAX Projects Management')
+
+@main.group(name="prax", help="Oceanum PRAX Projects Management")
 def prax():
     pass
 
-@prax.group(name='list', help='List resources')
+
+@prax.group(name="list", help="List resources")
 def list_group():
     pass
 
-@prax.group(name='describe',help='Describe resources')
+
+@prax.group(name="describe", help="Describe resources")
 def describe():
     pass
 
-@prax.group(name='delete', help='Delete resources')
+
+@prax.group(name="delete", help="Delete resources")
 def delete():
     pass
 
-@prax.group(name='update',help='Update resources')
+
+@prax.group(name="update", help="Update resources")
 def update():
     pass
 
-@prax.group(name='create',help='Create resources')
+
+@prax.group(name="create", help="Create resources")
 def create():
     pass
 
-@prax.group(name='submit',help='Submit Tasks, Pipelines and Builds runs.')
+
+@prax.group(name="submit", help="Submit Tasks, Pipelines and Builds runs.")
 def submit():
     pass
 
-@prax.group(name='terminate',help='Terminate Tasks, Pipelines and Builds runs.')
+
+@prax.group(name="terminate", help="Terminate Tasks, Pipelines and Builds runs.")
 def terminate():
     pass
 
-@prax.group(name='stop',help='Stop Tasks, Pipelines and Builds runs.')
+
+@prax.group(name="stop", help="Stop Tasks, Pipelines and Builds runs.")
 def stop():
     pass
 
-@prax.group(name='resume',help='Resume Tasks, Pipelines and Builds runs.')
+
+@prax.group(name="resume", help="Resume Tasks, Pipelines and Builds runs.")
 def resume():
     pass
 
-@prax.group(name='retry',help='Retry Tasks, Pipelines and Builds runs.')
+
+@prax.group(name="retry", help="Retry Tasks, Pipelines and Builds runs.")
 def retry():
     pass
 
-@prax.group(name='allow',help='Manage resources permissions')
+
+@prax.group(name="allow", help="Manage resources permissions")
 def allow():
     pass
 
-@prax.group(name='logs',help='View container logs')
+
+@prax.group(name="logs", help="View container logs")
 def logs():
     pass
 
-@prax.group(name='download', help='Download artifacts')
+
+@prax.group(name="download", help="Download artifacts")
 def download():
     pass

--- a/src/oceanum/cli/prax/project.py
+++ b/src/oceanum/cli/prax/project.py
@@ -3,72 +3,89 @@ from os import linesep
 
 import click
 
-from oceanum.cli.renderer import Renderer, RenderField
-from oceanum.cli.utils import format_dt
 from oceanum.cli.auth import login_required
-from oceanum.cli.symbols import spin, chk, err, wrn, info, key
+from oceanum.cli.renderer import Renderer, RenderField
+from oceanum.cli.symbols import chk, err, info, key, spin, wrn
+from oceanum.cli.utils import format_dt
 
-from .client import PRAXClient
-from .main import list_group, describe, delete, prax, update, allow
 from . import models
+from .client import PRAXClient
+from .main import allow, delete, describe, list_group, prax, update
 from .utils import (
-    echoerr, merge_secrets, format_permissions_display,
+    echoerr,
+    format_permissions_display,
+    merge_secrets,
     project_status_color as psc,
-    stage_status_color as ssc,
     source_status_color as sosc,
+    stage_status_color as ssc,
 )
 
-name_argument = click.argument('name', type=str)
-name_option = click.option('--name', help='Set the resource name', required=False, type=str)
-project_name_option = click.option('--project', help='Set Project Name', required=False, type=str)
-project_org_option = click.option('--org', help='Set Project Organization', required=False, type=str)
-project_user_option = click.option('--user', help='Set Project Owner email', required=False, type=str)
-project_stage_option = click.option('--stage', help='Set Project Stage', required=False, type=str)
+name_argument = click.argument("name", type=str)
+name_option = click.option(
+    "--name", help="Set the resource name", required=False, type=str
+)
+project_name_option = click.option(
+    "--project", help="Set Project Name", required=False, type=str
+)
+project_org_option = click.option(
+    "--org", help="Set Project Organization", required=False, type=str
+)
+project_user_option = click.option(
+    "--user", help="Set Project Owner email", required=False, type=str
+)
+project_stage_option = click.option(
+    "--stage", help="Set Project Stage", required=False, type=str
+)
 
-@list_group.command(name='projects', help='List PRAX Projects')
+
+@list_group.command(name="projects", help="List PRAX Projects")
 @click.pass_context
-@click.option('--search', help='Search by project name or description', default=None, type=str)
-@click.option('--status', help='filter by Project status', default=None, type=str)
+@click.option(
+    "--search", help="Search by project name or description", default=None, type=str
+)
+@click.option("--status", help="filter by Project status", default=None, type=str)
 @project_org_option
 @project_user_option
 @login_required
-def list_projects(ctx: click.Context, search: str|None, org: str|None, user: str|None, status: str|None):
-    click.echo(f' {spin} Listing projects...')
+def list_projects(
+    ctx: click.Context,
+    search: str | None,
+    org: str | None,
+    user: str | None,
+    status: str | None,
+):
+    click.echo(f" {spin} Listing projects...")
     client = PRAXClient(ctx)
-    filters = {
-        'search': search,
-        'org': org,
-        'user': user,
-        'status': status
-    }
-    projects = client.list_projects(**{
-        k: v for k, v in filters.items() if v is not None
-    })
+    filters = {"search": search, "org": org, "user": user, "status": status}
+    projects = client.list_projects(
+        **{k: v for k, v in filters.items() if v is not None}
+    )
 
     fields = [
-        RenderField(label='Name', path='$.name'),
-        RenderField(label='Org.', path='$.org'),
-        RenderField(label='Rev.', path='$.last_revision.number'),
-        RenderField(label='Status', path='$.status', mod=psc),
-        RenderField(label='Stages', path='$.stages.*', mod=ssc),
+        RenderField(label="Name", path="$.name"),
+        RenderField(label="Org.", path="$.org"),
+        RenderField(label="Rev.", path="$.last_revision.number"),
+        RenderField(label="Status", path="$.status", mod=psc),
+        RenderField(label="Stages", path="$.stages.*", mod=ssc),
     ]
 
     if not projects:
-        click.echo(f' {wrn} No projects found!')
+        click.echo(f" {wrn} No projects found!")
         sys.exit(1)
     elif isinstance(projects, models.ErrorResponse):
         click.echo(f" {err} Could not list projects!")
         echoerr(projects)
         sys.exit(1)
     else:
-        click.echo(Renderer(data=projects, fields=fields).render(output_format='table'))
+        click.echo(Renderer(data=projects, fields=fields).render(output_format="table"))
 
-@prax.command(name='validate', help='Validate PRAX Project Specfile')
-@click.argument('specfile', type=click.Path(exists=True))
+
+@prax.command(name="validate", help="Validate PRAX Project Specfile")
+@click.argument("specfile", type=click.Path(exists=True))
 @click.pass_context
 @login_required
 def validate_project(ctx: click.Context, specfile: click.Path):
-    click.echo(f' {spin} Validating PRAX Project Spec file...')
+    click.echo(f" {spin} Validating PRAX Project Spec file...")
     client = PRAXClient(ctx)
     response = client.validate(str(specfile))
     if isinstance(response, models.ErrorResponse):
@@ -76,29 +93,36 @@ def validate_project(ctx: click.Context, specfile: click.Path):
         echoerr(response)
         sys.exit(1)
     else:
-        click.echo(f' {chk} OK! Project Spec file is valid!')
+        click.echo(f" {chk} OK! Project Spec file is valid!")
 
-@prax.command(name='deploy', help='Deploy a PRAX Project Specfile')
+
+@prax.command(name="deploy", help="Deploy a PRAX Project Specfile")
 @name_option
 @project_org_option
 @project_user_option
-@click.option('--wait', help='Wait for project to be deployed', default=True)
+@click.option("--wait", help="Wait for project to be deployed", default=True)
 # Add option to allow passing secrets to the specfile, this will be used to replace placeholders
 # can be multiple, e.g. --secret secret-1:key1=value1,key2=value2 --secret secret-2:key2=value2
-@click.option('-s','--secrets',help='Replace existing secret data values, i.e secret-name:key1=value1,key2=value2', multiple=True)
-@click.argument('specfile', type=click.Path(exists=True, dir_okay=False, resolve_path=True))
+@click.option(
+    "-s",
+    "--secrets",
+    help="Replace existing secret data values, i.e secret-name:key1=value1,key2=value2",
+    multiple=True,
+)
+@click.argument(
+    "specfile", type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
 @click.pass_context
 @login_required
 def deploy_project(
     ctx: click.Context,
     specfile: click.Path,
-    name: str|None,
-    org: str|None,
-    user: str|None,
+    name: str | None,
+    org: str | None,
+    user: str | None,
     wait: bool,
-    secrets: list[str]
+    secrets: list[str],
 ):
-
     client = PRAXClient(ctx)
     project_spec = client.load_spec(str(specfile))
     if isinstance(project_spec, models.ErrorResponse):
@@ -114,25 +138,25 @@ def deploy_project(
         project_spec.member_ref = user
 
     if secrets:
-        click.echo(f' {key} Parsing and merging secrets...')
+        click.echo(f" {key} Parsing and merging secrets...")
         project_spec = merge_secrets(project_spec, secrets)
 
-    user_org = getattr(project_spec.user_ref, 'root', None) or ctx.obj.token.active_org
+    user_org = getattr(project_spec.user_ref, "root", None) or ctx.obj.token.active_org
     user_email = project_spec.member_ref or ctx.obj.token.email
 
     get_params = {
-        'project_name': project_spec.name,
-        'org': user_org,
-        'user': user_email
+        "project_name": project_spec.name,
+        "org": user_org,
+        "user": user_email,
     }
     project = client.get_project(**get_params)
-    click.echo(f'Using domain: {ctx.obj.token.domain}')
-    click.echo('')
+    click.echo(f"Using domain: {ctx.obj.token.domain}")
+    click.echo("")
 
     if isinstance(project, models.ProjectDetailsSchema):
         click.echo(f" {spin} Updating existing PRAX Project:")
     else:
-        if 'not found' in str(project.detail).lower():
+        if "not found" in str(project.detail).lower():
             click.echo(f" {spin} Deploying NEW PRAX Project:")
         else:
             click.echo(f" {err} Could not deploy project!")
@@ -140,11 +164,11 @@ def deploy_project(
             sys.exit(1)
 
     click.echo()
-    click.echo(f'  Project Name: {project_spec.name}')
+    click.echo(f"  Project Name: {project_spec.name}")
     click.echo(f"  Organization: {user_org}")
-    click.echo(f'  Owner:        {user_email}')
+    click.echo(f"  Owner:        {user_email}")
     click.echo()
-    click.echo('Safe to Ctrl+C at any time...')
+    click.echo("Safe to Ctrl+C at any time...")
     click.echo()
     project = client.deploy_project(project_spec)
     if isinstance(project, models.ErrorResponse):
@@ -152,34 +176,42 @@ def deploy_project(
         click.echo(f" {wrn} {project.detail}")
         sys.exit(1)
     project = client.get_project(**get_params)
-    if isinstance(project, models.ProjectDetailsSchema) and project.last_revision is not None:
-        click.echo(f" {chk} Revision #{project.last_revision.number} created successfully!")
+    if (
+        isinstance(project, models.ProjectDetailsSchema)
+        and project.last_revision is not None
+    ):
+        click.echo(
+            f" {chk} Revision #{project.last_revision.number} created successfully!"
+        )
         if wait:
-            click.echo(f' {spin} Waiting for project to be deployed...')
+            click.echo(f" {spin} Waiting for project to be deployed...")
             client.wait_project_deployment(**get_params)
     else:
         click.echo(f" {err} Could not retrieve project details!")
         click.echo(f" {wrn} Please check the project status in the PRAX console!")
 
-@delete.command(name='project')
-@click.argument('project_name', type=str)
+
+@delete.command(name="project")
+@click.argument("project_name", type=str)
 @project_org_option
 @project_user_option
 @click.pass_context
 @login_required
-def delete_project(ctx: click.Context, project_name: str, org: str|None, user:str|None):
+def delete_project(
+    ctx: click.Context, project_name: str, org: str | None, user: str | None
+):
     client = PRAXClient(ctx)
     project = client.get_project(project_name, org=org, user=user)
     if isinstance(project, models.ProjectDetailsSchema):
         click.confirm(
-            f"Deleting project:{linesep}"\
-            f"{linesep}"\
-            f"Project Name: {project_name}{linesep}"\
-            f"Org: {project.org}{linesep}"\
-            f"Owner: {project.owner}{linesep}"\
-            f"{linesep}"\
+            f"Deleting project:{linesep}"
+            f"{linesep}"
+            f"Project Name: {project_name}{linesep}"
+            f"Org: {project.org}{linesep}"
+            f"Owner: {project.owner}{linesep}"
+            f"{linesep}"
             "This will attempt to remove all deployed resources for this project! Are you sure?",
-            abort=True
+            abort=True,
         )
         response = client.delete_project(project_name, org=org, user=user)
         if isinstance(response, models.ErrorResponse):
@@ -187,40 +219,57 @@ def delete_project(ctx: click.Context, project_name: str, org: str|None, user:st
             echoerr(response)
             sys.exit(1)
         else:
-            click.echo(f' {chk} Project {project_name} deleted successfuly!')
-            click.echo(f' {info} Deployed resources will be removed shortly...')
+            click.echo(f" {chk} Project {project_name} deleted successfuly!")
+            click.echo(f" {info} Deployed resources will be removed shortly...")
     else:
         click.echo(f" {err} Failed to delete project '{project_name}'!")
         echoerr(project)
         sys.exit(1)
 
-@describe.command(name='project', help='Describe a PRAX Project')
-@click.option('--show-spec', help='Show project spec', default=False, type=bool, is_flag=True)
-@click.option('--only-spec', help='Show only project spec', default=False, type=bool, is_flag=True)
-@click.argument('project_name', type=str)
+
+@describe.command(name="project", help="Describe a PRAX Project")
+@click.option(
+    "--show-spec", help="Show project spec", default=False, type=bool, is_flag=True
+)
+@click.option(
+    "--only-spec", help="Show only project spec", default=False, type=bool, is_flag=True
+)
+@click.argument("project_name", type=str)
 @project_org_option
 @project_user_option
 @click.pass_context
 @login_required
-def describe_project(ctx: click.Context, project_name: str, org: str, user:str, show_spec: bool=False, only_spec: bool=False):
+def describe_project(
+    ctx: click.Context,
+    project_name: str,
+    org: str,
+    user: str,
+    show_spec: bool = False,
+    only_spec: bool = False,
+):
     client = PRAXClient(ctx)
     project = client.get_project(project_name, org=org, user=user)
-    last_revision = project.last_revision if isinstance(project, models.ProjectDetailsSchema) else None
+    last_revision = (
+        project.last_revision
+        if isinstance(project, models.ProjectDetailsSchema)
+        else None
+    )
     project_spec = last_revision.spec if last_revision is not None else None
     click.echo()
+
     def render_revision(revision: models.RevisionDetailsSchema):
         revision_fields = [
-            RenderField(label='Revision', path='$.number'),
-            RenderField(label='Author', path='$.author'),
-            RenderField(label='Status', path='$.status'),
-            RenderField(label='Created At', path='$.created_at', mod=format_dt),
+            RenderField(label="Revision", path="$.number"),
+            RenderField(label="Author", path="$.author"),
+            RenderField(label="Status", path="$.status"),
+            RenderField(label="Created At", path="$.created_at", mod=format_dt),
         ]
 
-        click.echo(Renderer(
-            data=[revision],
-            fields=revision_fields,
-            indent=2
-        ).render(output_format='table', tablefmt='plain'))
+        click.echo(
+            Renderer(data=[revision], fields=revision_fields, indent=2).render(
+                output_format="table", tablefmt="plain"
+            )
+        )
         # click.echo(' '*2+'Spec:')
         # click.echo(Renderer(
         #     data=[revision.spec],
@@ -229,49 +278,55 @@ def describe_project(ctx: click.Context, project_name: str, org: str, user:str, 
         # ).render(output_format='yaml'))
 
     def render_stage_resources(resources: models.StageResourcesSchema):
-
         def render_resources(
-            resources: list[models.BuildSchema]|list[models.PipelineSchema]|list[models.RouteSchema]|list[models.TaskSchema],
+            resources: list[models.BuildSchema]
+            | list[models.PipelineSchema]
+            | list[models.RouteSchema]
+            | list[models.TaskSchema],
             extra_fields: list[RenderField],
-            indent: int = 6
+            indent: int = 6,
         ):
-            resource_type = resources[0].__class__.__name__.removesuffix('Schema').title()+'s'
-            click.echo(' '*max(0,indent-2)+f'{resource_type}:')
+            resource_type = (
+                resources[0].__class__.__name__.removesuffix("Schema").title() + "s"
+            )
+            click.echo(" " * max(0, indent - 2) + f"{resource_type}:")
             for resource in resources:
                 common_fields = [
-                    RenderField(label='Project Name', path='$.name'),
-                    RenderField(label='Description', path='$.description'),
-                    #RenderField(label='Object Ref.', path='$.object_ref'),
-                    RenderField(label='Updated At', path='$.updated_at', mod=format_dt),
-
+                    RenderField(label="Project Name", path="$.name"),
+                    RenderField(label="Description", path="$.description"),
+                    # RenderField(label='Object Ref.', path='$.object_ref'),
+                    RenderField(label="Updated At", path="$.updated_at", mod=format_dt),
                 ]
-                click.echo(Renderer(
-                    data=[resource],
-                    fields=common_fields+extra_fields,
-                    indent=indent
-                ).render(output_format='table', tablefmt='plain'))
+                click.echo(
+                    Renderer(
+                        data=[resource],
+                        fields=common_fields + extra_fields,
+                        indent=indent,
+                    ).render(output_format="table", tablefmt="plain")
+                )
                 if len(resources) > 1:
-                    click.echo(' '*indent+'-'*40)
+                    click.echo(" " * indent + "-" * 40)
             click.echo()
 
         pipeline_fields = [
-            RenderField(label='Last Run Status',
-                        path='$.last_run',
-                        mod=lambda x: x['status'] if x is not None else 'N/A'
+            RenderField(
+                label="Last Run Status",
+                path="$.last_run",
+                mod=lambda x: x["status"] if x is not None else "N/A",
             ),
         ]
 
         if resources.builds:
             build_fields = [
-                RenderField(label='Source Ref', path='$.source_ref'),
-                RenderField(label='Commit', path='$.commit_sha'),
-                RenderField(label='Image digest', path='$.image_digest'),
-            ]+pipeline_fields
+                RenderField(label="Source Ref", path="$.source_ref"),
+                RenderField(label="Commit", path="$.commit_sha"),
+                RenderField(label="Image digest", path="$.image_digest"),
+            ] + pipeline_fields
             render_resources(resources.builds, build_fields, indent=6)
 
         if resources.routes:
             route_fields = [
-                RenderField(label='Route Status', path='$.status'),
+                RenderField(label="Route Status", path="$.status"),
             ]
             render_resources(resources.routes, route_fields, indent=6)
 
@@ -283,37 +338,40 @@ def describe_project(ctx: click.Context, project_name: str, org: str, user:str, 
 
     def render_stage(stage: models.StageDetailsSchema):
         stage_fields = [
-            RenderField(label='Stage Name', path='$.name'),
-            RenderField(label='Status', path='$.status'),
-            RenderField(label='Updated At', path='$.updated_at', sep=linesep, mod=format_dt),
-            RenderField(label='Message', path='$.error_message', sep=linesep),
+            RenderField(label="Stage Name", path="$.name"),
+            RenderField(label="Status", path="$.status"),
+            RenderField(
+                label="Updated At", path="$.updated_at", sep=linesep, mod=format_dt
+            ),
+            RenderField(label="Message", path="$.error_message", sep=linesep),
         ]
-        click.echo(Renderer(
-            data=[stage],
-            fields=stage_fields,
-            indent=2
-        ).render(output_format='table', tablefmt='plain'))
-        click.echo(' '*2+'Deployed Resources:')
+        click.echo(
+            Renderer(data=[stage], fields=stage_fields, indent=2).render(
+                output_format="table", tablefmt="plain"
+            )
+        )
+        click.echo(" " * 2 + "Deployed Resources:")
         render_stage_resources(stage.resources)
 
     if isinstance(project, models.ProjectDetailsSchema) and project_spec is not None:
         render_fields = [
-            RenderField(label='Resource Name', path='$.name'),
-            RenderField(label='Description', path='$.description'),
-            RenderField(label='Organisation', path='$.org'),
-            RenderField(label='Owner', path='$.owner'),
-            RenderField(label='Created', path='$.created_at', mod=format_dt),
+            RenderField(label="Resource Name", path="$.name"),
+            RenderField(label="Description", path="$.description"),
+            RenderField(label="Organisation", path="$.org"),
+            RenderField(label="Owner", path="$.owner"),
+            RenderField(label="Created", path="$.created_at", mod=format_dt),
         ]
         #
-        click.echo('-'*40)
-        click.echo(Renderer(
-            data=[project],
-            fields=render_fields
-        ).render(output_format='table', tablefmt='plain'))
+        click.echo("-" * 40)
+        click.echo(
+            Renderer(data=[project], fields=render_fields).render(
+                output_format="table", tablefmt="plain"
+            )
+        )
         if project.last_revision is not None:
             click.echo("Latest Revision:")
             render_revision(project.last_revision)
-        click.echo('Stages:')
+        click.echo("Stages:")
         for stage in project.stages:
             render_stage(stage)
     else:
@@ -324,31 +382,41 @@ def describe_project(ctx: click.Context, project_name: str, org: str, user:str, 
         echoerr(project)
         sys.exit(1)
 
-@update.command(name='project', help='Update Project parameters')
-@click.argument('project_name', type=str)
+
+@update.command(name="project", help="Update Project parameters")
+@click.argument("project_name", type=str)
 @project_org_option
 @project_user_option
-@click.option('--description', help='Update project description', default=None, type=str)
-@click.option('--active', help='Update project status', default=None, type=bool)
+@click.option(
+    "--description", help="Update project description", default=None, type=str
+)
+@click.option("--active", help="Update project status", default=None, type=bool)
 @click.pass_context
-def update_project(ctx: click.Context, project_name: str, description: str, org: str, user:str, active: bool):
+def update_project(
+    ctx: click.Context,
+    project_name: str,
+    description: str,
+    org: str,
+    user: str,
+    active: bool,
+):
     client = PRAXClient(ctx)
     project = client.get_project(project_name, org=org, user=user)
     ops = []
     if isinstance(project, models.ProjectDetailsSchema):
         project.description = description
         if description:
-            ops.append(models.JSONPatchOpSchema(
-                op=models.Op('replace'),
-                path='/description',
-                value=description
-            ))
+            ops.append(
+                models.JSONPatchOpSchema(
+                    op=models.Op("replace"), path="/description", value=description
+                )
+            )
         if active is not None:
-            ops.append(models.JSONPatchOpSchema(
-                op=models.Op('replace'),
-                path='/active',
-                value=active
-            ))
+            ops.append(
+                models.JSONPatchOpSchema(
+                    op=models.Op("replace"), path="/active", value=active
+                )
+            )
         project = client.patch_project(project.name, ops)
         if isinstance(project, models.ProjectDetailsSchema):
             click.echo(f"Project '{project_name}' description updated!")
@@ -359,27 +427,52 @@ def update_project(ctx: click.Context, project_name: str, description: str, org:
         sys.exit(1)
 
 
-@allow.command(name='project')
-@click.argument('project_name', type=str, required=True)
+@allow.command(name="project")
+@click.argument("project_name", type=str, required=True)
 @project_org_option
-@click.option('-g','--group', required=False, multiple=True)
-@click.option('-u','--user', required=False, multiple=True)
-@click.option('-a','--assign', help='Allow to assign project permissions', default=None, type=bool)
-@click.option('-v','--view', help='Allow to view the project', default=None, type=bool)
-@click.option('-c','--change', help='Allow to change the project, implies --view=True', default=None, type=bool)
-@click.option('-d','--delete', help='Allow to delete the project, implies --view=True and --change=True', default=None, type=bool)
+@click.option("-g", "--group", required=False, multiple=True)
+@click.option("-u", "--user", required=False, multiple=True)
+@click.option(
+    "-a",
+    "--assign",
+    help="Allow to assign project permissions",
+    default=None,
+    type=bool,
+)
+@click.option("-v", "--view", help="Allow to view the project", default=None, type=bool)
+@click.option(
+    "-c",
+    "--change",
+    help="Allow to change the project, implies --view=True",
+    default=None,
+    type=bool,
+)
+@click.option(
+    "-d",
+    "--delete",
+    help="Allow to delete the project, implies --view=True and --change=True",
+    default=None,
+    type=bool,
+)
 @click.pass_context
-def allow_project(ctx: click.Context, project_name: str, org: str, group: tuple[str],
-                  user: tuple[str], assign: bool, view: bool, change: bool,
-                  delete: bool):
-
+def allow_project(
+    ctx: click.Context,
+    project_name: str,
+    org: str,
+    group: tuple[str],
+    user: tuple[str],
+    assign: bool,
+    view: bool,
+    change: bool,
+    delete: bool,
+):
     def _get_perm(subject: str):
         return models.PermissionsSchema(
             subject=subject,
             view=view if view is not None else None,
             change=change if change is not None else None,
             assign=assign if assign is not None else None,
-            delete=delete if delete is not None else None
+            delete=delete if delete is not None else None,
         )
 
     client = PRAXClient(ctx)
@@ -398,42 +491,51 @@ def allow_project(ctx: click.Context, project_name: str, org: str, group: tuple[
         echoerr(response)
         sys.exit(1)
 
-@list_group.command(name='sources', help='List PRAX Project Sources')
+
+@list_group.command(name="sources", help="List PRAX Project Sources")
 @click.pass_context
 @project_name_option
 @project_org_option
 @project_user_option
-@click.option('--search', help='Search by project name or description', default=None, type=str)
-@click.option('--status', help='filter by Project status', default=None, type=str)
-def list_sources(ctx: click.Context, project: str|None, org: str|None,
-                 user: str|None, search: str|None, status: str|None):
-    click.echo(f' {spin} Listing sources...')
+@click.option(
+    "--search", help="Search by project name or description", default=None, type=str
+)
+@click.option("--status", help="filter by Project status", default=None, type=str)
+def list_sources(
+    ctx: click.Context,
+    project: str | None,
+    org: str | None,
+    user: str | None,
+    search: str | None,
+    status: str | None,
+):
+    click.echo(f" {spin} Listing sources...")
     client = PRAXClient(ctx)
     filters = {
-        'search': search,
-        'project': project,
-        'org': org,
-        'user': user,
-        'status': status,
+        "search": search,
+        "project": project,
+        "org": org,
+        "user": user,
+        "status": status,
     }
     sources = client.list_sources(**filters)
 
     fields = [
-        RenderField(label='Name', path='$.name'),
-        RenderField(label='Org.', path='$.org'),
-        RenderField(label='Project', path='$project'),
-        RenderField(label='Stage', path='$.stage'),
-        RenderField(label='Type', path='$.source_type', mod=lambda x: x.title()),
-        RenderField(label='Repository', path='$.repository'),
-        RenderField(label='Status', path='$.status', mod=sosc),
+        RenderField(label="Name", path="$.name"),
+        RenderField(label="Org.", path="$.org"),
+        RenderField(label="Project", path="$project"),
+        RenderField(label="Stage", path="$.stage"),
+        RenderField(label="Type", path="$.source_type", mod=lambda x: x.title()),
+        RenderField(label="Repository", path="$.repository"),
+        RenderField(label="Status", path="$.status", mod=sosc),
     ]
 
     if not sources:
-        click.echo(f' {wrn} No sources found!')
+        click.echo(f" {wrn} No sources found!")
         sys.exit(1)
     elif isinstance(sources, models.ErrorResponse):
         click.echo(f" {err} Could not list sources!")
         echoerr(sources)
         sys.exit(1)
     else:
-        click.echo(Renderer(data=sources, fields=fields).render(output_format='table'))
+        click.echo(Renderer(data=sources, fields=fields).render(output_format="table"))

--- a/src/oceanum/cli/prax/project.py
+++ b/src/oceanum/cli/prax/project.py
@@ -219,7 +219,7 @@ def delete_project(
             echoerr(response)
             sys.exit(1)
         else:
-            click.echo(f" {chk} Project {project_name} deleted successfuly!")
+            click.echo(f" {chk} Project {project_name} deleted successfully!")
             click.echo(f" {info} Deployed resources will be removed shortly...")
     else:
         click.echo(f" {err} Failed to delete project '{project_name}'!")

--- a/src/oceanum/cli/prax/route.py
+++ b/src/oceanum/cli/prax/route.py
@@ -1,60 +1,83 @@
 import sys
-import yaml
 from os import linesep
 
 import click
+import yaml
 
-from oceanum.cli.renderer import Renderer, output_format_option, RenderField
 from oceanum.cli.auth import login_required
-from oceanum.cli.symbols import wrn, chk, info, err
+from oceanum.cli.renderer import Renderer, RenderField, output_format_option
+from oceanum.cli.symbols import err, wrn
+
 from . import models
-from .main import list_group, describe, update, allow, logs
 from .client import PRAXClient
+from .main import allow, describe, list_group, logs, update
+from .utils import echoerr, format_permissions_display, format_route_status as _frs
 
-from .utils import format_route_status as _frs, echoerr, format_permissions_display
 
-@update.group(name='route', help='Update PRAX Routes')
+@update.group(name="route", help="Update PRAX Routes")
 def update_route():
     pass
 
-@list_group.command(name='routes', help='List PRAX Routes')
+
+@list_group.command(name="routes", help="List PRAX Routes")
 @click.pass_context
-@click.option('--search', help='Search by route name, project_name or project description',
-              default=None, type=str)
-@click.option('--org', help='Organization name', default=None, type=str)
-@click.option('--user', help='Route owner email', default=None, type=str)
-@click.option('--status', help='Route status', default=None, type=str)
-@click.option('--project', help='Project name', default=None, type=str)
-@click.option('--stage', help='Stage name', default=None, type=str)
-@click.option('--open-access', help='Show only open-access routes or private routes with False', default=None, type=bool, is_flag=True)
-@click.option('--tier', help="Select only 'frontend' or 'backend' routes", default=None, type=click.Choice(['backend','frontend']))
-@click.option('--current-org', help='Filter routes by the current organization in Oceanum.io', default=False, type=bool, is_flag=True)
+@click.option(
+    "--search",
+    help="Search by route name, project_name or project description",
+    default=None,
+    type=str,
+)
+@click.option("--org", help="Organization name", default=None, type=str)
+@click.option("--user", help="Route owner email", default=None, type=str)
+@click.option("--status", help="Route status", default=None, type=str)
+@click.option("--project", help="Project name", default=None, type=str)
+@click.option("--stage", help="Stage name", default=None, type=str)
+@click.option(
+    "--open-access",
+    help="Show only open-access routes or private routes with False",
+    default=None,
+    type=bool,
+    is_flag=True,
+)
+@click.option(
+    "--tier",
+    help="Select only 'frontend' or 'backend' routes",
+    default=None,
+    type=click.Choice(["backend", "frontend"]),
+)
+@click.option(
+    "--current-org",
+    help="Filter routes by the current organization in Oceanum.io",
+    default=False,
+    type=bool,
+    is_flag=True,
+)
 @output_format_option
 @login_required
-def list_routes(ctx: click.Context, output: str, open_access: bool, current_org: bool, **filters):
+def list_routes(
+    ctx: click.Context, output: str, open_access: bool, current_org: bool, **filters
+):
     if open_access:
-        filters.update({'open': True})
+        filters.update({"open": True})
     elif open_access is None:
         pass
     else:
-        filters.update({'open': False})
+        filters.update({"open": False})
 
     if current_org:
-        filters.update({'active_org': True})
+        filters.update({"active_org": True})
 
     client = PRAXClient(ctx)
     fields = [
-        RenderField(label='Route Name', path='$.name'),
-        RenderField(label='Project', path='$.project'),
-        RenderField(label='Stage', path='$.stage'),
-        RenderField(label='Status', path='$.status', mod=_frs),
-        RenderField(label='URL', path='$.url'),
+        RenderField(label="Route Name", path="$.name"),
+        RenderField(label="Project", path="$.project"),
+        RenderField(label="Stage", path="$.stage"),
+        RenderField(label="Status", path="$.status", mod=_frs),
+        RenderField(label="URL", path="$.url"),
     ]
-    routes =  client.list_routes(**{
-        k: v for k, v in filters.items() if v is not None
-    })
+    routes = client.list_routes(**{k: v for k, v in filters.items() if v is not None})
     if not routes:
-        click.echo(f' {wrn} No routes found!')
+        click.echo(f" {wrn} No routes found!")
     elif isinstance(routes, models.ErrorResponse):
         click.echo(f" {err} Error fetching routes:")
         echoerr(routes)
@@ -62,70 +85,87 @@ def list_routes(ctx: click.Context, output: str, open_access: bool, current_org:
     else:
         click.echo(Renderer(data=routes, fields=fields).render(output_format=output))
 
-@list_group.command(name='notebooks', help='List PRAX Notebooks')
+
+@list_group.command(name="notebooks", help="List PRAX Notebooks")
 @click.pass_context
-@click.option('--search', help='Search by notebook name, project_name or project description',
-              default=None, type=str)
-@click.option('--org', help='Organization name', default=None, type=str)
-@click.option('--user', help='Notebook owner email', default=None, type=str)
-@click.option('--status', help='Notebook status', default=None, type=str)
-@click.option('--project', help='Project name', default=None, type=str)
-@click.option('--stage', help='Stage name', default=None, type=str)
-@click.option('--open-access', help='Show only open-access notebooks or private notebooks with False', default=None, type=bool, is_flag=True)
+@click.option(
+    "--search",
+    help="Search by notebook name, project_name or project description",
+    default=None,
+    type=str,
+)
+@click.option("--org", help="Organization name", default=None, type=str)
+@click.option("--user", help="Notebook owner email", default=None, type=str)
+@click.option("--status", help="Notebook status", default=None, type=str)
+@click.option("--project", help="Project name", default=None, type=str)
+@click.option("--stage", help="Stage name", default=None, type=str)
+@click.option(
+    "--open-access",
+    help="Show only open-access notebooks or private notebooks with False",
+    default=None,
+    type=bool,
+    is_flag=True,
+)
 @output_format_option
 @login_required
 def list_notebooks(ctx: click.Context, output: str, open_access: bool, **filters):
-    filters.update({'notebook': True})
+    filters.update({"notebook": True})
     ctx.invoke(list_routes, output=output, open_access=open_access, **filters)
 
-@describe.command(name='route', help='Describe a PRAX Service or App Route')
+
+@describe.command(name="route", help="Describe a PRAX Service or App Route")
 @click.pass_context
-@click.argument('route_name', type=str)
+@click.argument("route_name", type=str)
 @login_required
 def describe_route(ctx: click.Context, route_name: str):
     client = PRAXClient(ctx)
     route = client.get_route(route_name)
     if isinstance(route, models.RouteSchema):
         fields = [
-            RenderField(label='Name', path='$.name'),
-            RenderField(label='Description', path='$.description'),
-            RenderField(label='Project', path='$.project'),
-            RenderField(label='Service', path='$.service_name'),
-            RenderField(label='Stage', path='$.stage'),
-            RenderField(label='Org', path='$.org'),
-            RenderField(label='Default URL', path='$.url'),
-            RenderField(label='Created At', path='$.created_at'),
-            RenderField(label='Updated At', path='$.updated_at'),
-            RenderField(label='Current Revision', path='$.revision'),
-            RenderField(label='Next Revision', path='$.next_revision'),
-            RenderField(label='Next Revision Status', path='$.next_revision_status'),
+            RenderField(label="Name", path="$.name"),
+            RenderField(label="Description", path="$.description"),
+            RenderField(label="Project", path="$.project"),
+            RenderField(label="Service", path="$.service_name"),
+            RenderField(label="Stage", path="$.stage"),
+            RenderField(label="Org", path="$.org"),
+            RenderField(label="Default URL", path="$.url"),
+            RenderField(label="Created At", path="$.created_at"),
+            RenderField(label="Updated At", path="$.updated_at"),
+            RenderField(label="Current Revision", path="$.revision"),
+            RenderField(label="Next Revision", path="$.next_revision"),
+            RenderField(label="Next Revision Status", path="$.next_revision_status"),
             RenderField(
-                label='Custom Domains',
-                path='$.custom_domains.*',
+                label="Custom Domains",
+                path="$.custom_domains.*",
                 sep=linesep,
-                mod=lambda x: f'https://{x}' if x else None
+                mod=lambda x: f"https://{x}" if x else None,
             ),
-            RenderField(label='Publish App', path='$.publish_app'),
-            RenderField(label='Open Access', path='$.open_access'),
-            RenderField(label='Thumbnail URL', path='$.thumbnail'),
-            RenderField(label='Status', path='$.status'),
-            RenderField(label='Details', path='$.details',
-                        mod=lambda x: yaml.dump(x, indent=4) if x else None
+            RenderField(label="Publish App", path="$.publish_app"),
+            RenderField(label="Open Access", path="$.open_access"),
+            RenderField(label="Thumbnail URL", path="$.thumbnail"),
+            RenderField(label="Status", path="$.status"),
+            RenderField(
+                label="Details",
+                path="$.details",
+                mod=lambda x: yaml.dump(x, indent=4) if x else None,
             ),
         ]
 
         click.echo(
-            Renderer(data=[route], fields=fields).render(output_format='table', tablefmt='plain')
+            Renderer(data=[route], fields=fields).render(
+                output_format="table", tablefmt="plain"
+            )
         )
     else:
         click.echo(f" {err} Error fetching route:")
         echoerr(route)
         sys.exit(1)
 
-@update_route.command(name='thumbnail', help='Update a PRAX Route thumbnail')
+
+@update_route.command(name="thumbnail", help="Update a PRAX Route thumbnail")
 @click.pass_context
-@click.argument('route_name', type=str)
-@click.argument('thumbnail_file', type=click.File('rb'))
+@click.argument("route_name", type=str)
+@click.argument("thumbnail_file", type=click.File("rb"))
 @login_required
 def update_thumbnail(ctx: click.Context, route_name: str, thumbnail_file: click.File):
     client = PRAXClient(ctx)
@@ -142,24 +182,38 @@ def update_thumbnail(ctx: click.Context, route_name: str, thumbnail_file: click.
         click.echo(f"Route '{route_name}' not found!")
 
 
-@allow.command(name='route')
-@click.argument('route_name', type=str, required=True)
-@click.option('-g','--group', required=False, multiple=True)
-@click.option('-u','--user', required=False, multiple=True)
-@click.option('-v','--view', help='Allow to view the route', default=None, type=bool)
-@click.option('-c','--change', help='Allow to change the route, implies --view=True', default=None, type=bool)
-@click.option('-a','--assign', help='Allow to assign route permissions', default=None, type=bool)
+@allow.command(name="route")
+@click.argument("route_name", type=str, required=True)
+@click.option("-g", "--group", required=False, multiple=True)
+@click.option("-u", "--user", required=False, multiple=True)
+@click.option("-v", "--view", help="Allow to view the route", default=None, type=bool)
+@click.option(
+    "-c",
+    "--change",
+    help="Allow to change the route, implies --view=True",
+    default=None,
+    type=bool,
+)
+@click.option(
+    "-a", "--assign", help="Allow to assign route permissions", default=None, type=bool
+)
 @click.pass_context
 @login_required
-def allow_route(ctx: click.Context, route_name: str, group: tuple[str],
-                user: tuple[str], view: bool, change: bool, assign: bool):
-
+def allow_route(
+    ctx: click.Context,
+    route_name: str,
+    group: tuple[str],
+    user: tuple[str],
+    view: bool,
+    change: bool,
+    assign: bool,
+):
     def _get_perm(subject: str):
         return models.PermissionsSchema(
             subject=subject,
             view=view if view is not None else None,
             change=change if change is not None else None,
-            assign=assign if assign is not None else None
+            assign=assign if assign is not None else None,
         )
 
     client = PRAXClient(ctx)
@@ -178,11 +232,14 @@ def allow_route(ctx: click.Context, route_name: str, group: tuple[str],
         echoerr(response)
         sys.exit(1)
 
-@logs.command(name='route', help='Get logs for a PRAX Route')
+
+@logs.command(name="route", help="Get logs for a PRAX Route")
 @click.pass_context
-@click.argument('route_name', type=str)
-@click.option('-n','--lines', help='Number of lines to show', default=1000, type=int)
-@click.option('-f','--follow', help='Follow logs', default=False, type=bool, is_flag=True)
+@click.argument("route_name", type=str)
+@click.option("-n", "--lines", help="Number of lines to show", default=1000, type=int)
+@click.option(
+    "-f", "--follow", help="Follow logs", default=False, type=bool, is_flag=True
+)
 @login_required
 def get_route_logs(ctx: click.Context, route_name: str, lines: int, follow: bool):
     client = PRAXClient(ctx)

--- a/src/oceanum/cli/prax/user.py
+++ b/src/oceanum/cli/prax/user.py
@@ -1,36 +1,43 @@
 import os
+
 import click
 
-from oceanum.cli.renderer import Renderer, RenderField
-from oceanum.cli.symbols import err, chk, wrn
 from oceanum.cli.auth import login_required
+from oceanum.cli.renderer import Renderer, RenderField
+from oceanum.cli.symbols import chk, err, wrn
 
 from . import models
-from .main import describe, create
 from .client import PRAXClient
-
+from .main import create, describe
 from .utils import echoerr
 
-@describe.command(name='user', help='List PRAX Users')
-@click.option('--org', help='Organization name to show resources for', default=None, type=str)
+
+@describe.command(name="user", help="List PRAX Users")
+@click.option(
+    "--org", help="Organization name to show resources for", default=None, type=str
+)
 @click.pass_context
 @login_required
-def describe_user(ctx: click.Context, org: str|None):
+def describe_user(ctx: click.Context, org: str | None):
     client = PRAXClient(ctx)
     fields = [
-        RenderField(label='Username', path='$.username'),
-        RenderField(label='Email', path='$.email'),
-        RenderField(label='PRAX API Token', path='$.token'),
-        RenderField(label='Current Org.', path='$.current_org.name'),
-        RenderField(label='Member of Orgs.', path='$.all_orgs.*', sep=os.linesep),
-        RenderField(label='Deployable Orgs.', path='$.deployable_orgs.*', sep=os.linesep),
-        RenderField(label='Admin Orgs.', path='$.admin_orgs.*', sep=os.linesep),
-        RenderField(label='Deployed Projects', path='$.projects.*', sep=os.linesep),
+        RenderField(label="Username", path="$.username"),
+        RenderField(label="Email", path="$.email"),
+        RenderField(label="PRAX API Token", path="$.token"),
+        RenderField(label="Current Org.", path="$.current_org.name"),
+        RenderField(label="Member of Orgs.", path="$.all_orgs.*", sep=os.linesep),
         RenderField(
-            label=f'User-Resources:',
-            path='$.current_org.resources.*',
+            label="Deployable Orgs.", path="$.deployable_orgs.*", sep=os.linesep
+        ),
+        RenderField(label="Admin Orgs.", path="$.admin_orgs.*", sep=os.linesep),
+        RenderField(label="Deployed Projects", path="$.projects.*", sep=os.linesep),
+        RenderField(
+            label="User-Resources:",
+            path="$.current_org.resources.*",
             sep=os.linesep,
-            mod=lambda x: f"{x['resource_type'].removesuffix('s')}: {x['name']} (keys: {','.join(x['spec']['data'].keys())})"
+            mod=lambda x: (
+                f"{x['resource_type'].removesuffix('s')}: {x['name']} (keys: {','.join(x['spec']['data'].keys())})"
+            ),
         ),
     ]
     users = client.get_users()
@@ -47,52 +54,98 @@ def describe_user(ctx: click.Context, org: str|None):
         echoerr(users)
         return 1
     else:
-        click.echo(Renderer(data=users, fields=fields).render_table(tablefmt='plain'))
+        click.echo(Renderer(data=users, fields=fields).render_table(tablefmt="plain"))
         user_org = users[0].current_org
         if user_org is not None:
             quotas = list(user_org.tier.model_fields.keys())
             usage = user_org.usage.model_dump()
             tier = user_org.tier.model_dump()
-            quota_data = {quotas[i]: j for i, j in enumerate(
-                            zip(usage.values(), tier.values()))}
+            quota_data = {
+                quotas[i]: j for i, j in enumerate(zip(usage.values(), tier.values()))
+            }
             mod = lambda x: f"{x[0]} / {x[1]}"
             cpu_fields = [
-                RenderField(label='Total CPU (millicores)', path='$.max_cpu', mod=mod),
-                RenderField(label='CPU per Service (millicores)', path='$.max_cpu_per_service', mod=mod),
-                RenderField(label='CPU per Task (millicores)', path='$.max_cpu_per_task', mod=mod),
-                RenderField(label='Total GPU (cores)', path='$.max_gpu', mod=mod),
+                RenderField(label="Total CPU (millicores)", path="$.max_cpu", mod=mod),
+                RenderField(
+                    label="CPU per Service (millicores)",
+                    path="$.max_cpu_per_service",
+                    mod=mod,
+                ),
+                RenderField(
+                    label="CPU per Task (millicores)",
+                    path="$.max_cpu_per_task",
+                    mod=mod,
+                ),
+                RenderField(label="Total GPU (cores)", path="$.max_gpu", mod=mod),
             ]
             ram_fields = [
-                RenderField(label='Total Memory (MB)', path='$.max_memory', mod=mod),
-                RenderField(label='Memory per Service (MB)', path='$.max_memory_per_service', mod=mod),
-                RenderField(label='Memory per Task (MB)', path='$.max_memory_per_task', mod=mod),
+                RenderField(label="Total Memory (MB)", path="$.max_memory", mod=mod),
+                RenderField(
+                    label="Memory per Service (MB)",
+                    path="$.max_memory_per_service",
+                    mod=mod,
+                ),
+                RenderField(
+                    label="Memory per Task (MB)", path="$.max_memory_per_task", mod=mod
+                ),
             ]
             ephemeral_storage_fields = [
-                RenderField(label='Ephemeral Storage (MB)', path='$.max_ephemeral_storage', mod=mod),
-                RenderField(label='Ephemeral Storage per Service (MB)', path='$.max_ephemeral_storage_per_service', mod=mod),
-                RenderField(label='Ephemeral Storage per Task (MB)', path='$.max_ephemeral_storage_per_task', mod=mod),
+                RenderField(
+                    label="Ephemeral Storage (MB)",
+                    path="$.max_ephemeral_storage",
+                    mod=mod,
+                ),
+                RenderField(
+                    label="Ephemeral Storage per Service (MB)",
+                    path="$.max_ephemeral_storage_per_service",
+                    mod=mod,
+                ),
+                RenderField(
+                    label="Ephemeral Storage per Task (MB)",
+                    path="$.max_ephemeral_storage_per_task",
+                    mod=mod,
+                ),
             ]
             persistent_storage_fields = [
-                RenderField(label='Total Persistent Storage (MB)', path='$.max_persistent_storage', mod=mod),
-                RenderField(label='Persistent Storage Size (MB)', path='$.max_persistent_volume_size', mod=mod),
-                RenderField(label='Number of Persistent Volumes', path='$.max_persistent_volumes', mod=mod),
+                RenderField(
+                    label="Total Persistent Storage (MB)",
+                    path="$.max_persistent_storage",
+                    mod=mod,
+                ),
+                RenderField(
+                    label="Persistent Storage Size (MB)",
+                    path="$.max_persistent_volume_size",
+                    mod=mod,
+                ),
+                RenderField(
+                    label="Number of Persistent Volumes",
+                    path="$.max_persistent_volumes",
+                    mod=mod,
+                ),
             ]
 
             project_limits_fields = [
-                RenderField(label='Total Projects', path='$.max_projects', mod=mod),
-                RenderField(label='Total Stages', path='$.max_stages', mod=mod),
-                RenderField(label='Total Builds', path='$.max_builds', mod=mod),
-                RenderField(label='Total Private Images', path='$.max_images', mod=mod),
-                RenderField(label='Total Sources', path='$.max_sources', mod=mod),
-                RenderField(label='Total Pipelines', path='$.max_pipelines', mod=mod),
-                RenderField(label='Total Tasks', path='$.max_tasks', mod=mod),
-                RenderField(label='Total Notebooks', path='$.max_notebooks', mod=mod),
-                RenderField(label='Total Services', path='$.max_services', mod=mod),
-                RenderField(label='Total Secrets', path='$.max_secrets', mod=mod),
-                RenderField(label='Total Config-maps', path='$.max_configmaps', mod=mod),
-                #RenderField(label='Total Concurrent Runs', path='$.max_concurrent_workflows', mod=mod),
+                RenderField(label="Total Projects", path="$.max_projects", mod=mod),
+                RenderField(label="Total Stages", path="$.max_stages", mod=mod),
+                RenderField(label="Total Builds", path="$.max_builds", mod=mod),
+                RenderField(label="Total Private Images", path="$.max_images", mod=mod),
+                RenderField(label="Total Sources", path="$.max_sources", mod=mod),
+                RenderField(label="Total Pipelines", path="$.max_pipelines", mod=mod),
+                RenderField(label="Total Tasks", path="$.max_tasks", mod=mod),
+                RenderField(label="Total Notebooks", path="$.max_notebooks", mod=mod),
+                RenderField(label="Total Services", path="$.max_services", mod=mod),
+                RenderField(label="Total Secrets", path="$.max_secrets", mod=mod),
+                RenderField(
+                    label="Total Config-maps", path="$.max_configmaps", mod=mod
+                ),
+                # RenderField(label='Total Concurrent Runs', path='$.max_concurrent_workflows', mod=mod),
             ]
-            compute_fields = cpu_fields + ram_fields + ephemeral_storage_fields + persistent_storage_fields
+            compute_fields = (
+                cpu_fields
+                + ram_fields
+                + ephemeral_storage_fields
+                + persistent_storage_fields
+            )
 
             click.echo()
             click.echo(f"Resource Quotas for Organization: {user_org.name}")
@@ -100,30 +153,46 @@ def describe_user(ctx: click.Context, org: str|None):
             click.echo()
             click.echo("Compute Resources:             (Usage / Limit)")
             click.echo("---------------------------------------------")
-            click.echo(Renderer(data=quota_data, fields=compute_fields).render_table(tablefmt='plain'))
+            click.echo(
+                Renderer(data=quota_data, fields=compute_fields).render_table(
+                    tablefmt="plain"
+                )
+            )
             click.echo()
             click.echo("Project Resource Limits:   (Usage / Limit)")
             click.echo("------------------------------------------")
-            click.echo(Renderer(data=quota_data, fields=project_limits_fields).render_table(tablefmt='plain'))
+            click.echo(
+                Renderer(data=quota_data, fields=project_limits_fields).render_table(
+                    tablefmt="plain"
+                )
+            )
         return 0
 
 
-@create.command(name='user-secret', help='Create a new PRAX User Secret (API Token)')
+@create.command(name="user-secret", help="Create a new PRAX User Secret (API Token)")
 @click.pass_context
-@click.argument('name', type=str)
-@click.option('--org', help='Organization name. Defaults to your current Org.', default=None, type=str)
-@click.option('--description', help='Secret description', type=str, default=None)
-@click.option('--data','-d', help='Secret data key=value pairs', type=str, multiple=True)
+@click.argument("name", type=str)
+@click.option(
+    "--org",
+    help="Organization name. Defaults to your current Org.",
+    default=None,
+    type=str,
+)
+@click.option("--description", help="Secret description", type=str, default=None)
+@click.option(
+    "--data", "-d", help="Secret data key=value pairs", type=str, multiple=True
+)
 @login_required
-def create_user_secret(ctx: click.Context,
-                       name: str,
-                       org: str|None,
-                       description: str|None,
-                       data: list[str],
+def create_user_secret(
+    ctx: click.Context,
+    name: str,
+    org: str | None,
+    description: str | None,
+    data: list[str],
 ):
     client = PRAXClient(ctx)
     users = client.get_users()
-    
+
     if isinstance(users, models.ErrorResponse):
         click.echo(f" {err} Error fetching User information:")
         echoerr(users)
@@ -135,25 +204,29 @@ def create_user_secret(ctx: click.Context,
         return 1
 
     if not user.current_org:
-        click.echo(f" {err} No organization specified and user '{user.username}' has no current Org.")
+        click.echo(
+            f" {err} No organization specified and user '{user.username}' has no current Org."
+        )
         return 1
-    
+
     org = org or user.current_org.name
-    user_id = getattr(user.email, 'root', user.username)
-    
+    user_id = getattr(user.email, "root", user.username)
+
     if org not in user.admin_orgs:
         click.echo(f" {err} Failed to create or update User-Secret!")
-        click.echo(f" {wrn} User '{user_id}' cannot manage User Resources from Organization '{org}'")
+        click.echo(
+            f" {wrn} User '{user_id}' cannot manage User Resources from Organization '{org}'"
+        )
         return 1
 
     try:
-        secret_data = {s[0]: s[1] for s in [d.split('=') for d in data]}
+        secret_data = {s[0]: s[1] for s in [d.split("=") for d in data]}
     except ValueError:
         click.echo(f" {err} Failed to create or update User-Secret!")
         click.echo(f" {wrn} Error parsing secret data. Please provide key=value pairs.")
-    
+
         return 1
-    
+
     secret = client.create_or_update_user_secret(name, org, secret_data, description)
 
     if isinstance(secret, models.ErrorResponse):
@@ -161,4 +234,6 @@ def create_user_secret(ctx: click.Context,
         echoerr(secret)
         return 1
     else:
-        click.echo(f" {chk} User-Secret '{secret.name}' created successfully in '{org}' namespace!")
+        click.echo(
+            f" {chk} User-Secret '{secret.name}' created successfully in '{org}' namespace!"
+        )

--- a/src/oceanum/cli/prax/user.py
+++ b/src/oceanum/cli/prax/user.py
@@ -219,13 +219,14 @@ def create_user_secret(
         )
         return 1
 
-    try:
-        secret_data = {s[0]: s[1] for s in [d.split("=") for d in data]}
-    except ValueError:
-        click.echo(f" {err} Failed to create or update User-Secret!")
-        click.echo(f" {wrn} Error parsing secret data. Please provide key=value pairs.")
-
-        return 1
+    secret_data = {}
+    for item in data:
+        parts = item.split("=", 1)
+        if len(parts) != 2 or not parts[0]:
+            click.echo(f" {err} Failed to create or update User-Secret!")
+            click.echo(f" {wrn} Error parsing secret data. Please provide key=value pairs.")
+            return 1
+        secret_data[parts[0]] = parts[1]
 
     secret = client.create_or_update_user_secret(name, org, secret_data, description)
 

--- a/src/oceanum/cli/prax/user.py
+++ b/src/oceanum/cli/prax/user.py
@@ -224,7 +224,9 @@ def create_user_secret(
         parts = item.split("=", 1)
         if len(parts) != 2 or not parts[0]:
             click.echo(f" {err} Failed to create or update User-Secret!")
-            click.echo(f" {wrn} Error parsing secret data. Please provide key=value pairs.")
+            click.echo(
+                f" {wrn} Error parsing secret data. Please provide key=value pairs."
+            )
             return 1
         secret_data[parts[0]] = parts[1]
 

--- a/src/oceanum/cli/prax/utils.py
+++ b/src/oceanum/cli/prax/utils.py
@@ -1,75 +1,83 @@
-
 import click
 
-from oceanum.cli.symbols import wrn, chk, info
+from oceanum.cli.symbols import chk, info, wrn
 
-from .models import ErrorResponse, ProjectSpec, SecretData, ResourcePermissionsSchema, PermissionsSchema
+from .models import (
+    ErrorResponse,
+    PermissionsSchema,
+    ProjectSpec,
+    ResourcePermissionsSchema,
+    SecretData,
+)
+
 
 def format_run_status(status: str) -> str:
     status = status.lower()
-    if status == 'pending':
-        return click.style(status.upper(), fg='white')
-    elif status == 'running':
-        return click.style(status.upper(), fg='cyan')
-    elif status == 'succeeded':
-        return click.style(status.upper(), fg='green')
-    elif status == 'failed':
-        return click.style(status.upper(), fg='red')
-    elif status == 'error':
-        return click.style(status.upper(), fg='red')
+    if status == "pending":
+        return click.style(status.upper(), fg="white")
+    elif status == "running":
+        return click.style(status.upper(), fg="cyan")
+    elif status == "succeeded":
+        return click.style(status.upper(), fg="green")
+    elif status == "failed":
+        return click.style(status.upper(), fg="red")
+    elif status == "error":
+        return click.style(status.upper(), fg="red")
     else:
         return status
+
 
 def format_route_status(status: str) -> str:
-    if status == 'online':
-        return click.style(status.upper(), fg='green')
-    elif status == 'offline':
-        return click.style(status.upper(), fg='black')
-    elif status == 'pending':
-        return click.style(status.upper(), fg='yellow')
-    elif status == 'starting':
-        return click.style(status.upper(), fg='cyan')
-    elif status == 'error':
-        return click.style(status.upper(), fg='red', bold=True)
+    if status == "online":
+        return click.style(status.upper(), fg="green")
+    elif status == "offline":
+        return click.style(status.upper(), fg="black")
+    elif status == "pending":
+        return click.style(status.upper(), fg="yellow")
+    elif status == "starting":
+        return click.style(status.upper(), fg="cyan")
+    elif status == "error":
+        return click.style(status.upper(), fg="red", bold=True)
     else:
         return status
-    
+
 
 def project_status_color(status: str) -> str:
-    if status == 'ready':
-        return click.style(status.upper(), fg='green')
-    elif status == 'degraded':
-        return click.style(status.upper(), fg='yellow')
-    elif status == 'updating':
-        return click.style(status.upper(), fg='cyan')
-    elif status == 'error':
-        return click.style(status.upper(), fg='red')
+    if status == "ready":
+        return click.style(status.upper(), fg="green")
+    elif status == "degraded":
+        return click.style(status.upper(), fg="yellow")
+    elif status == "updating":
+        return click.style(status.upper(), fg="cyan")
+    elif status == "error":
+        return click.style(status.upper(), fg="red")
     else:
-        return click.style(status.upper(), fg='white')
-        
+        return click.style(status.upper(), fg="white")
+
+
 def stage_status_color(stage: dict) -> str:
-    if stage['status'] == 'healthy':
-        return click.style(stage['name'], fg='green')
-    elif stage['status'] == 'degraded':
-        return click.style(stage['name'], fg='yellow')
-    elif stage['status'] == 'error':
-        return click.style(stage['name'], fg='red')
-    elif stage['status'] == 'updating':
-        return click.style(stage['name'], fg='cyan')
+    if stage["status"] == "healthy":
+        return click.style(stage["name"], fg="green")
+    elif stage["status"] == "degraded":
+        return click.style(stage["name"], fg="yellow")
+    elif stage["status"] == "error":
+        return click.style(stage["name"], fg="red")
+    elif stage["status"] == "updating":
+        return click.style(stage["name"], fg="cyan")
     else:
-        return stage['name']
-    
+        return stage["name"]
+
 
 def source_status_color(status: str) -> str:
-    if status == 'connected':
-        return click.style(status.upper(), fg='green')
-    elif status == 'disconnected':
-        return click.style(status.upper(), fg='red')
-    elif status == 'pending':
-        return click.style(status.upper(), fg='yellow')
-    elif status == 'forbidden':
-        return click.style(status.upper(), fg='red')
-    return click.style(status.upper(), fg='white')
+    if status == "connected":
+        return click.style(status.upper(), fg="green")
+    elif status == "disconnected":
+        return click.style(status.upper(), fg="red")
+    elif status == "pending":
+        return click.style(status.upper(), fg="yellow")
+    elif status == "forbidden":
+        return click.style(status.upper(), fg="red")
+    return click.style(status.upper(), fg="white")
 
 
 def echoerr(error: ErrorResponse):
@@ -84,12 +92,13 @@ def echoerr(error: ErrorResponse):
     elif error.detail is None:
         click.echo(f" {wrn} No error message provided!")
 
+
 def parse_secrets(secrets: list) -> list[dict]:
     parsed_secrets = []
     for secret in secrets:
-        secret_name, secret_data = secret.split(':')
-        secret_data = dict([s.split('=') for s in secret_data.split(',')])
-        secret_dict = {'name': secret_name, 'data': secret_data}
+        secret_name, secret_data = secret.split(":")
+        secret_data = dict([s.split("=") for s in secret_data.split(",")])
+        secret_dict = {"name": secret_name, "data": secret_data}
         parsed_secrets.append(secret_dict)
     return parsed_secrets
 
@@ -97,81 +106,97 @@ def parse_secrets(secrets: list) -> list[dict]:
 def merge_secrets(project_spec: ProjectSpec, secrets: list[str]) -> ProjectSpec:
     for secret in parse_secrets(secrets):
         if project_spec.resources is not None:
-            if secret['name'] not in [s.name for s in project_spec.resources.secrets]:
+            if secret["name"] not in [s.name for s in project_spec.resources.secrets]:
                 raise Exception(f"Secret '{secret['name']}' not found in project spec!")
             for existing_secret in project_spec.resources.secrets:
-                if existing_secret.name == secret['name']:
+                if existing_secret.name == secret["name"]:
                     if isinstance(existing_secret.data, SecretData):
                         if existing_secret.data.root is None:
-                            existing_secret.data.root = secret['data']
+                            existing_secret.data.root = secret["data"]
                         else:
-                            existing_secret.data.root.update(secret['data'])
+                            existing_secret.data.root.update(secret["data"])
                     else:
-                        existing_secret.data.update(secret['data'])
+                        existing_secret.data.update(secret["data"])
     return project_spec
 
 
-def format_permissions_display(permissions: ResourcePermissionsSchema, resource_name: str, resource_type: str = "resource") -> None:
+def format_permissions_display(
+    permissions: ResourcePermissionsSchema,
+    resource_name: str,
+    resource_type: str = "resource",
+) -> None:
     """
     Display resource permissions in a nice, readable format.
-    
+
     Args:
         permissions: The ResourcePermissionsSchema object to display
         resource_name: Name of the resource (e.g., project name, route name)
         resource_type: Type of resource (e.g., "project", "route")
     """
+
     def format_permission_value(value: bool | None) -> str:
         if value is True:
-            return click.style("✓", fg='green', bold=True)
+            return click.style("✓", fg="green", bold=True)
         elif value is False:
-            return click.style("✗", fg='red', bold=True)
+            return click.style("✗", fg="red", bold=True)
         else:
-            return click.style("−", fg='yellow')
-    
+            return click.style("−", fg="yellow")
+
     def display_permissions_table(perms_list: list[PermissionsSchema], title: str):
         if not perms_list:
             click.echo(f"    No {title.lower()} permissions set")
             return
-            
+
         click.echo(f"    {click.style(title + ':', fg='blue', bold=True)}")
         click.echo()
-        
+
         # Table header
-        click.echo(click.style(f"    {'Subject':<30} {'View':<6} {'Change':<8} {'Delete':<8} {'Assign':<6}", bold=True))
+        click.echo(
+            click.style(
+                f"    {'Subject':<30} {'View':<6} {'Change':<8} {'Delete':<8} {'Assign':<6}",
+                bold=True,
+            )
+        )
         click.echo(click.style("    " + "─" * 60, dim=True))
-        
+
         # Table rows
         for perm in perms_list:
-            subject = perm.subject[:28] + ".." if len(perm.subject) > 30 else perm.subject
-            
+            subject = (
+                perm.subject[:28] + ".." if len(perm.subject) > 30 else perm.subject
+            )
+
             # Use fixed positions instead of string formatting for styled text
             parts = [
                 f"    {subject:<30}",
-                f"  {format_permission_value(perm.view)}     ", # View column (6 chars)
-                f"  {format_permission_value(perm.change)}      ", # Change column (8 chars)  
-                f"  {format_permission_value(perm.delete)}      ", # Delete column (8 chars)
-                f"  {format_permission_value(perm.assign)}"      # Assign column (6 chars)
+                f"  {format_permission_value(perm.view)}     ",  # View column (6 chars)
+                f"  {format_permission_value(perm.change)}      ",  # Change column (8 chars)
+                f"  {format_permission_value(perm.delete)}      ",  # Delete column (8 chars)
+                f"  {format_permission_value(perm.assign)}",  # Assign column (6 chars)
             ]
-            
+
             click.echo("".join(parts))
         click.echo()
-    
-    click.echo(f" {chk} Permissions for {resource_type} '{resource_name}' updated successfully!")
+
+    click.echo(
+        f" {chk} Permissions for {resource_type} '{resource_name}' updated successfully!"
+    )
     click.echo()
     click.echo(f" {info} Current permissions:")
     click.echo()
-    
+
     # Display users permissions
     display_permissions_table(permissions.users, "Users")
-    
-    # Display groups permissions  
+
+    # Display groups permissions
     display_permissions_table(permissions.groups, "Groups")
-    
+
     if not permissions.users and not permissions.groups:
         click.echo("    No permissions currently set for this resource.")
         click.echo()
-    
+
     # Legend
-    click.echo("    " + click.style("Legend:", fg='cyan', bold=True))
-    click.echo(f"    {format_permission_value(True)} = Granted   {format_permission_value(False)} = Denied   {format_permission_value(None)} = Not set")
+    click.echo("    " + click.style("Legend:", fg="cyan", bold=True))
+    click.echo(
+        f"    {format_permission_value(True)} = Granted   {format_permission_value(False)} = Denied   {format_permission_value(None)} = Not set"
+    )
     click.echo()

--- a/src/oceanum/cli/prax/workflows.py
+++ b/src/oceanum/cli/prax/workflows.py
@@ -25,7 +25,13 @@ def parse_parameters(parameters: list[str] | None) -> dict | None:
     params = {}
     if parameters is not None:
         for p in parameters:
-            key, value = p.split("=")
+            parts = p.split("=", 1)
+            if len(parts) != 2:
+                raise click.BadParameter(
+                    f"Invalid parameter format '{p}'. Expected 'key=value'.",
+                    param_hint="'--parameter'",
+                )
+            key, value = parts
             params[key] = value
     return params or None
 

--- a/src/oceanum/cli/prax/workflows.py
+++ b/src/oceanum/cli/prax/workflows.py
@@ -1,54 +1,56 @@
 import sys
 import time
+
 import click
 
-from oceanum.cli.renderer import Renderer, output_format_option, RenderField
 from oceanum.cli.auth import login_required
+from oceanum.cli.renderer import Renderer, RenderField, output_format_option
 from oceanum.cli.symbols import chk, err, spin, wrn
 from oceanum.cli.utils import format_dt
 
 from . import models
-from .main import list_group, describe, submit, terminate, retry, logs, delete, download
 from .client import PRAXClient
+from .main import delete, describe, download, list_group, logs, retry, submit, terminate
 from .project import (
-    project_org_option,
-    project_user_option,
-    project_stage_option,
+    name_argument,
     project_name_option,
-    name_argument
+    project_org_option,
+    project_stage_option,
+    project_user_option,
 )
 from .utils import echoerr, format_run_status as frs
 
-def parse_parameters(parameters: list[str]|None) -> dict|None:
+
+def parse_parameters(parameters: list[str] | None) -> dict | None:
     params = {}
     if parameters is not None:
         for p in parameters:
-            key, value = p.split('=')
+            key, value = p.split("=")
             params[key] = value
     return params or None
 
 
 LIST_FIELDS = [
-    RenderField(label='Name', path='$.name'),
-    RenderField(label='Project', path='$.project'),
-    RenderField(label='Stage', path='$.stage'),
-    RenderField(label='Org.', path='$.org'),
+    RenderField(label="Name", path="$.name"),
+    RenderField(label="Project", path="$.project"),
+    RenderField(label="Stage", path="$.stage"),
+    RenderField(label="Org.", path="$.org"),
     RenderField(
-        label='Last Run',
-        path='$.last_run',
-        mod=lambda x: frs(x['status']) if x is not None else 'N/A'
+        label="Last Run",
+        path="$.last_run",
+        mod=lambda x: frs(x["status"]) if x is not None else "N/A",
     ),
     RenderField(
-        label='Started at',
-        path='$.last_run',
-        mod=lambda x: x['started_at'] if x is not None else 'N/A'
+        label="Started at",
+        path="$.last_run",
+        mod=lambda x: x["started_at"] if x is not None else "N/A",
     ),
 ]
 
-@list_group.command(name='pipelines', help='List PRAX Pipelines')
+
+@list_group.command(name="pipelines", help="List PRAX Pipelines")
 @click.pass_context
-@click.option('--search', help='Search by names or description',
-              default=None, type=str)
+@click.option("--search", help="Search by names or description", default=None, type=str)
 @project_org_option
 @project_user_option
 @project_name_option
@@ -57,38 +59,40 @@ LIST_FIELDS = [
 @login_required
 def list_pipelines(ctx: click.Context, output: str, **filters):
     client = PRAXClient(ctx)
-    pipelines =  client.list_pipelines(**filters)
+    pipelines = client.list_pipelines(**filters)
+
     def format_schedule(x: list) -> list[str]:
         if len(x) == 2 and x[1] is not None:
             icon = spin if not x[0] else err
             return [f"{icon} {x[1]}"]
         else:
-            return ['N/A']
+            return ["N/A"]
 
     extra_fields = [
         RenderField(
-            label='Schedule',
+            label="Schedule",
             path='$.["suspended", "schedule"]',
             lmod=format_schedule,
-            sep=' '
+            sep=" ",
         ),
     ]
     if not pipelines:
-        click.echo(f' {wrn} No pipelines found!')
+        click.echo(f" {wrn} No pipelines found!")
     elif isinstance(pipelines, models.ErrorResponse):
         click.echo(f" {err} Error fetching pipelines:")
         echoerr(pipelines)
         sys.exit(1)
     else:
-        click.echo(Renderer(
-            data=pipelines,
-            fields=LIST_FIELDS+extra_fields
-        ).render(output_format=output))
+        click.echo(
+            Renderer(data=pipelines, fields=LIST_FIELDS + extra_fields).render(
+                output_format=output
+            )
+        )
 
-@list_group.command(name='tasks', help='List all PRAX Tasks')
+
+@list_group.command(name="tasks", help="List all PRAX Tasks")
 @click.pass_context
-@click.option('--search', help='Search by names or description',
-              default=None, type=str)
+@click.option("--search", help="Search by names or description", default=None, type=str)
 @project_org_option
 @project_user_option
 @project_name_option
@@ -97,17 +101,20 @@ def list_pipelines(ctx: click.Context, output: str, **filters):
 @login_required
 def list_tasks(ctx: click.Context, output: str, **filters):
     client = PRAXClient(ctx)
-    tasks =  client.list_tasks(**filters)
+    tasks = client.list_tasks(**filters)
     if not tasks:
-        click.echo(f' {wrn} No tasks found!')
+        click.echo(f" {wrn} No tasks found!")
     elif isinstance(tasks, models.ErrorResponse):
         click.echo(f" {err} Error fetching tasks:")
         echoerr(tasks)
         sys.exit(1)
     else:
-        click.echo(Renderer(data=tasks, fields=LIST_FIELDS).render(output_format=output))
+        click.echo(
+            Renderer(data=tasks, fields=LIST_FIELDS).render(output_format=output)
+        )
 
-@describe.command(name='task', help='Describe PRAX Task')
+
+@describe.command(name="task", help="Describe PRAX Task")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -119,61 +126,69 @@ def describe_task(ctx: click.Context, name: str, **filters):
     client = PRAXClient(ctx)
     task = client.get_task(name, **filters)
     task_fields = [
-        RenderField(label='Task Name', path='$.name'),
-        RenderField(label='Description', path='$.description'),
-        RenderField(label='Project', path='$.project'),
-        RenderField(label='Organization', path='$.org'),
-        RenderField(label='Stage', path='$.stage'),
-        RenderField(label='Created At', path='$.created_at', mod=format_dt),
-        RenderField(label='Updated At', path='$.updated_at', mod=format_dt),
+        RenderField(label="Task Name", path="$.name"),
+        RenderField(label="Description", path="$.description"),
+        RenderField(label="Project", path="$.project"),
+        RenderField(label="Organization", path="$.org"),
+        RenderField(label="Stage", path="$.stage"),
+        RenderField(label="Created At", path="$.created_at", mod=format_dt),
+        RenderField(label="Updated At", path="$.updated_at", mod=format_dt),
     ]
     run_fields = [
-        RenderField(label='Status', path='$.status'),
-        RenderField(label='Started at', path='$.started_at', mod=format_dt),
-        RenderField(label='Finished at', path='$.finished_at', mod=lambda x: format_dt(x) if x is not None else 'N/A'),
-        RenderField(label='Message', path='$.message'),
+        RenderField(label="Status", path="$.status"),
+        RenderField(label="Started at", path="$.started_at", mod=format_dt),
+        RenderField(
+            label="Finished at",
+            path="$.finished_at",
+            mod=lambda x: format_dt(x) if x is not None else "N/A",
+        ),
+        RenderField(label="Message", path="$.message"),
     ]
     if isinstance(task, models.TaskSchema):
-        click.echo(Renderer(
-            data=[task],
-            fields=task_fields
-        ).render(output_format='table', tablefmt='plain'))
+        click.echo(
+            Renderer(data=[task], fields=task_fields).render(
+                output_format="table", tablefmt="plain"
+            )
+        )
         if task.last_run:
             click.echo("Last Run:")
-            click.echo(Renderer(
-                data=[task.last_run],
-                fields=run_fields,
-                indent=2
-            ).render(output_format='table', tablefmt='plain'))
+            click.echo(
+                Renderer(data=[task.last_run], fields=run_fields, indent=2).render(
+                    output_format="table", tablefmt="plain"
+                )
+            )
             if task.last_run.arguments:
                 click.echo("    Arguments:")
-                click.echo(Renderer(
-                    data=[task.last_run.arguments],
-                    fields=[],
-                    indent=4
-                ).render(output_format='yaml'))
+                click.echo(
+                    Renderer(
+                        data=[task.last_run.arguments], fields=[], indent=4
+                    ).render(output_format="yaml")
+                )
             if task.last_run.details:
                 click.echo("  Run Details:")
-                click.echo(Renderer(
-                    data=[task.last_run.details],
-                    fields=[],
-                    indent=2
-                ).render(output_format='yaml'))
+                click.echo(
+                    Renderer(data=[task.last_run.details], fields=[], indent=2).render(
+                        output_format="yaml"
+                    )
+                )
     else:
         click.echo(f" {err} Error fetching task:")
         echoerr(task)
         sys.exit(1)
 
-@submit.command(name='task', help='Submit PRAX Task')
+
+@submit.command(name="task", help="Submit PRAX Task")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-p','--parameter', help='Task parameters', default=None, type=str, multiple=True)
+@click.option(
+    "-p", "--parameter", help="Task parameters", default=None, type=str, multiple=True
+)
 @login_required
-def submit_task(ctx: click.Context, name: str, parameter: list[str]|None, **filters):
+def submit_task(ctx: click.Context, name: str, parameter: list[str] | None, **filters):
     client = PRAXClient(ctx)
     task = client.get_task(name, **filters)
 
@@ -188,10 +203,12 @@ def submit_task(ctx: click.Context, name: str, parameter: list[str]|None, **filt
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Task submitted successfully! Run ID: {'N/A' if resp.last_run is None else resp.last_run.name}")
+            click.echo(
+                f"{chk} Task submitted successfully! Run ID: {'N/A' if resp.last_run is None else resp.last_run.name}"
+            )
 
 
-@terminate.command(name='task', help='Terminate PRAX Task')
+@terminate.command(name="task", help="Terminate PRAX Task")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -221,14 +238,15 @@ def terminate_task(ctx: click.Context, name: str, **filters):
                     click.echo(f" {err} Error fetching task:")
                     echoerr(task)
                     sys.exit(1)
-                elif task and task.status == 'Running':
+                elif task and task.status == "Running":
                     time.sleep(1)
                     continue
                 else:
                     break
             click.echo(f"{chk} Task {task.name} terminated successfully!")
 
-@retry.command(name='task', help='Retry PRAX Task')
+
+@retry.command(name="task", help="Retry PRAX Task")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -250,18 +268,22 @@ def retry_task(ctx: click.Context, name: str, **filters):
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Task retried successfully! Run ID: {'N/A' if resp is None else resp.name}")
+            click.echo(
+                f"{chk} Task retried successfully! Run ID: {'N/A' if resp is None else resp.name}"
+            )
 
 
-@logs.command(name='task', help='Get the Latest Run PRAX Task logs')
+@logs.command(name="task", help="Get the Latest Run PRAX Task logs")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-n','--lines', help='Number of lines to show', default=1000, type=int)
-@click.option('-f','--follow', help='Follow logs', default=False, type=bool, is_flag=True)
+@click.option("-n", "--lines", help="Number of lines to show", default=1000, type=int)
+@click.option(
+    "-f", "--follow", help="Follow logs", default=False, type=bool, is_flag=True
+)
 @login_required
 def get_task_logs(ctx: click.Context, name: str, lines: int, follow: bool, **filters):
     client = PRAXClient(ctx)
@@ -274,7 +296,7 @@ def get_task_logs(ctx: click.Context, name: str, lines: int, follow: bool, **fil
             click.echo(f" {err} Error fetching Task:")
             echoerr(task_run)
             sys.exit(1)
-    
+
     click.echo(f"Fetching logs for Task-Run: {task_run.name} ...")
     for line in client.get_task_run_logs(task_run.name, lines, follow):
         if isinstance(line, models.ErrorResponse):
@@ -283,22 +305,31 @@ def get_task_logs(ctx: click.Context, name: str, lines: int, follow: bool, **fil
             sys.exit(1)
         click.echo(line)
 
-@download.command(name='task-artifact', help='Download PRAX Task output Artifact')
+
+@download.command(name="task-artifact", help="Download PRAX Task output Artifact")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-a','--artifact-name', help='Name of the artifact to download', required=True, type=str)
-@click.option('-o','--output', help='Output path to save the artifact (a .gz file)', default=None, type=str)
+@click.option(
+    "-a",
+    "--artifact-name",
+    help="Name of the artifact to download",
+    required=True,
+    type=str,
+)
+@click.option(
+    "-o",
+    "--output",
+    help="Output path to save the artifact (a .gz file)",
+    default=None,
+    type=str,
+)
 @login_required
 def download_task_artifact(
-    ctx: click.Context,
-    name: str,
-    artifact_name: str,
-    output: str|None,
-    **filters
+    ctx: click.Context, name: str, artifact_name: str, output: str | None, **filters
 ):
     client = PRAXClient(ctx)
     task = client.get_task(name, **filters)
@@ -310,17 +341,17 @@ def download_task_artifact(
     if task_run is None:
         click.echo(f" {err} No task run found for task: {name}")
         sys.exit(1)
-    
+
     if isinstance(task_run, models.ErrorResponse):
         click.echo(f" {err} Error fetching task run:")
         echoerr(task_run)
         sys.exit(1)
-    
+
     if client.download_task_run_artifact(task_run.name, artifact_name, output):
         click.echo(f" {chk} Artifact '{artifact_name}' downloaded successfully!")
 
 
-@delete.command(name='task', help='Delete PRAX Task')
+@delete.command(name="task", help="Delete PRAX Task")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -345,10 +376,9 @@ def delete_task(ctx: click.Context, name: str, **filters):
             click.echo(f"{chk} Task deleted successfully!")
 
 
-@list_group.command(name='builds', help='List all PRAX Builds')
+@list_group.command(name="builds", help="List all PRAX Builds")
 @click.pass_context
-@click.option('--search', help='Search by names or description',
-                default=None, type=str)
+@click.option("--search", help="Search by names or description", default=None, type=str)
 @project_org_option
 @project_user_option
 @project_name_option
@@ -357,24 +387,24 @@ def delete_task(ctx: click.Context, name: str, **filters):
 @login_required
 def list_builds(ctx: click.Context, output: str, **filters):
     build_fields = LIST_FIELDS + [
-        RenderField(label='Source Branch/Tag', path='$.source_ref'),
+        RenderField(label="Source Branch/Tag", path="$.source_ref"),
     ]
-    #build_fields.pop(-2)
+    # build_fields.pop(-2)
     client = PRAXClient(ctx)
-    builds =  client.list_builds(**{
-        k: v for k, v in filters.items() if v is not None
-    })
+    builds = client.list_builds(**{k: v for k, v in filters.items() if v is not None})
     if not builds:
-        click.echo(f' {wrn} No builds found!')
+        click.echo(f" {wrn} No builds found!")
     elif isinstance(builds, models.ErrorResponse):
         click.echo(f" {err} Error fetching builds:")
         echoerr(builds)
         sys.exit(1)
     else:
-        click.echo(Renderer(data=builds, fields=build_fields).render(output_format=output))
+        click.echo(
+            Renderer(data=builds, fields=build_fields).render(output_format=output)
+        )
 
 
-@describe.command(name='build', help='Describe PRAX Build')
+@describe.command(name="build", help="Describe PRAX Build")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -386,63 +416,71 @@ def describe_build(ctx: click.Context, name: str, **filters):
     client = PRAXClient(ctx)
     build = client.get_build(name, **filters)
     build_fields = [
-        RenderField(label='Build Name', path='$.name'),
-        RenderField(label='Description', path='$.description'),
-        RenderField(label='Project', path='$.project'),
-        RenderField(label='Organization', path='$.org'),
-        RenderField(label='Stage', path='$.stage'),
-        RenderField(label='Source Branch/Tag', path='$.source_ref'),
-        RenderField(label='Source Commit SHA', path='$.commit_sha'),
-        RenderField(label='Created At', path='$.created_at', mod=format_dt),
-        RenderField(label='Updated At', path='$.updated_at', mod=format_dt),
+        RenderField(label="Build Name", path="$.name"),
+        RenderField(label="Description", path="$.description"),
+        RenderField(label="Project", path="$.project"),
+        RenderField(label="Organization", path="$.org"),
+        RenderField(label="Stage", path="$.stage"),
+        RenderField(label="Source Branch/Tag", path="$.source_ref"),
+        RenderField(label="Source Commit SHA", path="$.commit_sha"),
+        RenderField(label="Created At", path="$.created_at", mod=format_dt),
+        RenderField(label="Updated At", path="$.updated_at", mod=format_dt),
     ]
     run_fields = [
-        RenderField(label='Status', path='$.status'),
-        RenderField(label='Started at', path='$.started_at', mod=format_dt),
-        RenderField(label='Finished at', path='$.finished_at', mod=lambda x: format_dt(x) if x is not None else 'N/A'),
-        RenderField(label='Message', path='$.message'),
+        RenderField(label="Status", path="$.status"),
+        RenderField(label="Started at", path="$.started_at", mod=format_dt),
+        RenderField(
+            label="Finished at",
+            path="$.finished_at",
+            mod=lambda x: format_dt(x) if x is not None else "N/A",
+        ),
+        RenderField(label="Message", path="$.message"),
     ]
     if isinstance(build, models.BuildSchema):
-        click.echo(Renderer(
-            data=[build],
-            fields=build_fields
-        ).render(output_format='table', tablefmt='plain'))
+        click.echo(
+            Renderer(data=[build], fields=build_fields).render(
+                output_format="table", tablefmt="plain"
+            )
+        )
         if build.last_run:
             click.echo("Last Run:")
-            click.echo(Renderer(
-                data=[build.last_run],
-                fields=run_fields,
-                indent=2
-            ).render(output_format='table', tablefmt='plain'))
+            click.echo(
+                Renderer(data=[build.last_run], fields=run_fields, indent=2).render(
+                    output_format="table", tablefmt="plain"
+                )
+            )
             if build.last_run.arguments:
                 click.echo("    Arguments:")
-                click.echo(Renderer(
-                    data=[build.last_run.arguments],
-                    fields=[],
-                    indent=4
-                ).render(output_format='yaml'))
+                click.echo(
+                    Renderer(
+                        data=[build.last_run.arguments], fields=[], indent=4
+                    ).render(output_format="yaml")
+                )
             if build.last_run.details:
                 click.echo("  Run Details:")
-                click.echo(Renderer(
-                    data=[build.last_run.details],
-                    fields=[],
-                    indent=2
-                ).render(output_format='yaml'))
+                click.echo(
+                    Renderer(data=[build.last_run.details], fields=[], indent=2).render(
+                        output_format="yaml"
+                    )
+                )
     else:
         click.echo(f" {err} Error fetching build:")
         echoerr(build)
         sys.exit(1)
 
-@submit.command(name='build', help='Submit PRAX Build')
+
+@submit.command(name="build", help="Submit PRAX Build")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-p','--parameter', help='Build parameters', default=None, type=str, multiple=True)
+@click.option(
+    "-p", "--parameter", help="Build parameters", default=None, type=str, multiple=True
+)
 @login_required
-def submit_build(ctx: click.Context, name: str, parameter: list[str]|None, **filters):
+def submit_build(ctx: click.Context, name: str, parameter: list[str] | None, **filters):
     client = PRAXClient(ctx)
     build = client.get_build(name, **filters)
     if isinstance(build, models.ErrorResponse):
@@ -456,9 +494,12 @@ def submit_build(ctx: click.Context, name: str, parameter: list[str]|None, **fil
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Build submitted successfully! Run ID: {'N/A' if resp.last_run is None else resp.last_run.name}")
+            click.echo(
+                f"{chk} Build submitted successfully! Run ID: {'N/A' if resp.last_run is None else resp.last_run.name}"
+            )
 
-@terminate.command(name='build', help='Terminate PRAX Build')
+
+@terminate.command(name="build", help="Terminate PRAX Build")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -480,9 +521,12 @@ def terminate_build(ctx: click.Context, name: str, **filters):
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Build terminated successfully! Run ID: {'N/A' if resp is None else resp.name}")
+            click.echo(
+                f"{chk} Build terminated successfully! Run ID: {'N/A' if resp is None else resp.name}"
+            )
 
-@retry.command(name='build', help='Retry PRAX Build')
+
+@retry.command(name="build", help="Retry PRAX Build")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -504,18 +548,22 @@ def retry_build(ctx: click.Context, name: str, **filters):
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Build retried successfully! Run ID: {'N/A' if resp is None else resp.name}")
+            click.echo(
+                f"{chk} Build retried successfully! Run ID: {'N/A' if resp is None else resp.name}"
+            )
 
 
-@logs.command(name='build', help='Get the Latest Run PRAX Build logs')
+@logs.command(name="build", help="Get the Latest Run PRAX Build logs")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-n','--lines', help='Number of lines to show', default=1000, type=int)
-@click.option('-f','--follow', help='Follow logs', default=False, type=bool, is_flag=True)
+@click.option("-n", "--lines", help="Number of lines to show", default=1000, type=int)
+@click.option(
+    "-f", "--follow", help="Follow logs", default=False, type=bool, is_flag=True
+)
 @login_required
 def get_build_logs(ctx: click.Context, name: str, lines: int, follow: bool, **filters):
     client = PRAXClient(ctx)
@@ -536,7 +584,8 @@ def get_build_logs(ctx: click.Context, name: str, lines: int, follow: bool, **fi
             sys.exit(1)
         click.echo(line)
 
-@delete.command(name='build', help='Delete PRAX Build')
+
+@delete.command(name="build", help="Delete PRAX Build")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -560,7 +609,8 @@ def delete_build(ctx: click.Context, name: str, **filters):
         else:
             click.echo(f"{chk} Build deleted successfully!")
 
-@describe.command(name='pipeline', help='Describe PRAX Pipeline')
+
+@describe.command(name="pipeline", help="Describe PRAX Pipeline")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -572,27 +622,35 @@ def describe_pipeline(ctx: click.Context, name: str, **filters):
     client = PRAXClient(ctx)
     pipeline = client.get_pipeline(name, **filters)
     pipeline_fields = [
-        RenderField(label='Pipeline Name', path='$.name'),
-        RenderField(label='Description', path='$.description'),
-        RenderField(label='Project', path='$.project'),
-        RenderField(label='Organization', path='$.org'),
-        RenderField(label='Stage', path='$.stage'),
-        RenderField(label='Schedule', path='$.schedule'),
-        RenderField(label='Suspended', path='$.suspended', ),
-        RenderField(label='Created At', path='$.created_at', mod=format_dt),
-        RenderField(label='Updated At', path='$.updated_at', mod=format_dt),
+        RenderField(label="Pipeline Name", path="$.name"),
+        RenderField(label="Description", path="$.description"),
+        RenderField(label="Project", path="$.project"),
+        RenderField(label="Organization", path="$.org"),
+        RenderField(label="Stage", path="$.stage"),
+        RenderField(label="Schedule", path="$.schedule"),
+        RenderField(
+            label="Suspended",
+            path="$.suspended",
+        ),
+        RenderField(label="Created At", path="$.created_at", mod=format_dt),
+        RenderField(label="Updated At", path="$.updated_at", mod=format_dt),
     ]
     run_fields = [
-        RenderField(label='Status', path='$.status'),
-        RenderField(label='Started at', path='$.started_at', mod=format_dt),
-        RenderField(label='Finished at', path='$.finished_at', mod=lambda x: format_dt(x) if x is not None else 'N/A'),
-        RenderField(label='Message', path='$.message'),
+        RenderField(label="Status", path="$.status"),
+        RenderField(label="Started at", path="$.started_at", mod=format_dt),
+        RenderField(
+            label="Finished at",
+            path="$.finished_at",
+            mod=lambda x: format_dt(x) if x is not None else "N/A",
+        ),
+        RenderField(label="Message", path="$.message"),
     ]
     if isinstance(pipeline, models.PipelineSchema):
-        click.echo(Renderer(
-            data=[pipeline],
-            fields=pipeline_fields
-        ).render(output_format='table', tablefmt='plain'))
+        click.echo(
+            Renderer(data=[pipeline], fields=pipeline_fields).render(
+                output_format="table", tablefmt="plain"
+            )
+        )
         # if pipeline.details:
         #     click.echo(f"  {chk} Pipeline Details:")
         #     click.echo(Renderer(
@@ -601,25 +659,25 @@ def describe_pipeline(ctx: click.Context, name: str, **filters):
         #     ).render(output_format='yaml'))
         if pipeline.last_run:
             click.echo("Last Run:")
-            click.echo(Renderer(
-                data=[pipeline.last_run],
-                fields=run_fields,
-                indent=2
-            ).render(output_format='table', tablefmt='plain'))
+            click.echo(
+                Renderer(data=[pipeline.last_run], fields=run_fields, indent=2).render(
+                    output_format="table", tablefmt="plain"
+                )
+            )
             if pipeline.last_run.arguments:
                 click.echo("    Arguments:")
-                click.echo(Renderer(
-                    data=[pipeline.last_run.arguments],
-                    fields=[],
-                    indent=4
-                ).render(output_format='yaml'))
+                click.echo(
+                    Renderer(
+                        data=[pipeline.last_run.arguments], fields=[], indent=4
+                    ).render(output_format="yaml")
+                )
             if pipeline.last_run.details:
                 click.echo("  Run Details:")
-                click.echo(Renderer(
-                    data=[pipeline.last_run.details],
-                    fields=[],
-                    indent=2
-                ).render(output_format='yaml'))
+                click.echo(
+                    Renderer(
+                        data=[pipeline.last_run.details], fields=[], indent=2
+                    ).render(output_format="yaml")
+                )
 
     else:
         click.echo(f" {err} Error fetching pipeline:")
@@ -627,16 +685,25 @@ def describe_pipeline(ctx: click.Context, name: str, **filters):
         sys.exit(1)
 
 
-@submit.command(name='pipeline', help='Submit PRAX Pipeline')
+@submit.command(name="pipeline", help="Submit PRAX Pipeline")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-p','--parameter', help='Pipeline parameters', default=None, type=str, multiple=True)
+@click.option(
+    "-p",
+    "--parameter",
+    help="Pipeline parameters",
+    default=None,
+    type=str,
+    multiple=True,
+)
 @login_required
-def submit_pipeline(ctx: click.Context, name: str, parameter: list[str]|None, **filters):
+def submit_pipeline(
+    ctx: click.Context, name: str, parameter: list[str] | None, **filters
+):
     client = PRAXClient(ctx)
     pipeline = client.get_pipeline(name, **filters)
     if isinstance(pipeline, models.ErrorResponse):
@@ -650,9 +717,12 @@ def submit_pipeline(ctx: click.Context, name: str, parameter: list[str]|None, **
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Pipeline submitted successfully! Run ID: {'N/A' if resp.last_run is None else resp.last_run.name}")
+            click.echo(
+                f"{chk} Pipeline submitted successfully! Run ID: {'N/A' if resp.last_run is None else resp.last_run.name}"
+            )
 
-@terminate.command(name='pipeline', help='Terminate PRAX Pipeline')
+
+@terminate.command(name="pipeline", help="Terminate PRAX Pipeline")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -674,10 +744,12 @@ def terminate_pipeline(ctx: click.Context, name: str, **filters):
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Pipeline terminated successfully! Run ID: {'N/A' if resp is None else resp.name}")
+            click.echo(
+                f"{chk} Pipeline terminated successfully! Run ID: {'N/A' if resp is None else resp.name}"
+            )
 
 
-@retry.command(name='pipeline', help='Retry PRAX Pipeline')
+@retry.command(name="pipeline", help="Retry PRAX Pipeline")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -699,19 +771,26 @@ def retry_pipeline(ctx: click.Context, name: str, **filters):
             echoerr(resp)
             sys.exit(1)
         else:
-            click.echo(f"{chk} Pipeline retried successfully! Run ID: {'N/A' if resp is None else resp.name}")
+            click.echo(
+                f"{chk} Pipeline retried successfully! Run ID: {'N/A' if resp is None else resp.name}"
+            )
 
-@logs.command(name='pipeline', help='Get the Latest Run PRAX Pipeline logs')
+
+@logs.command(name="pipeline", help="Get the Latest Run PRAX Pipeline logs")
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-n','--lines', help='Number of lines to show', default=1000, type=int)
-@click.option('-f','--follow', help='Follow logs', default=False, type=bool, is_flag=True)
+@click.option("-n", "--lines", help="Number of lines to show", default=1000, type=int)
+@click.option(
+    "-f", "--follow", help="Follow logs", default=False, type=bool, is_flag=True
+)
 @login_required
-def get_pipeline_logs(ctx: click.Context, name: str, lines: int, follow: bool, **filters):
+def get_pipeline_logs(
+    ctx: click.Context, name: str, lines: int, follow: bool, **filters
+):
     client = PRAXClient(ctx)
     pipeline = client.get_pipeline(name, **filters)
     if isinstance(pipeline, models.PipelineSchema):
@@ -723,31 +802,54 @@ def get_pipeline_logs(ctx: click.Context, name: str, lines: int, follow: bool, *
             echoerr(pipeline_run)
             sys.exit(1)
     click.echo(f"Fetching logs for Pipeline-Run: {pipeline_run.name} ...")
-    for line in client.get_pipeline_run_logs(pipeline_run.name, lines, follow, **filters):
+    for line in client.get_pipeline_run_logs(
+        pipeline_run.name, lines, follow, **filters
+    ):
         if isinstance(line, models.ErrorResponse):
             click.echo(f" {err} Error fetching logs:")
             echoerr(line)
             sys.exit(1)
         click.echo(line)
 
-@download.command(name='pipeline-artifact', help='Download PRAX Pipeline Step output Artifact')
+
+@download.command(
+    name="pipeline-artifact", help="Download PRAX Pipeline Step output Artifact"
+)
 @click.pass_context
 @name_argument
 @project_org_option
 @project_user_option
 @project_name_option
 @project_stage_option
-@click.option('-a','--artifact-name', help='Name of the artifact to download', required=True, type=str)
-@click.option('-s','--step-name', help='Name of the pipeline step which produced the artifact', required=True, type=str)
-@click.option('-o','--output', help='Output path to save the artifact (a .gz file)', default=None, type=str)
+@click.option(
+    "-a",
+    "--artifact-name",
+    help="Name of the artifact to download",
+    required=True,
+    type=str,
+)
+@click.option(
+    "-s",
+    "--step-name",
+    help="Name of the pipeline step which produced the artifact",
+    required=True,
+    type=str,
+)
+@click.option(
+    "-o",
+    "--output",
+    help="Output path to save the artifact (a .gz file)",
+    default=None,
+    type=str,
+)
 @login_required
 def download_pipeline_artifact(
     ctx: click.Context,
     name: str,
     artifact_name: str,
     step_name: str,
-    output: str|None = None,
-    **filters
+    output: str | None = None,
+    **filters,
 ):
     client = PRAXClient(ctx)
     pipeline = client.get_pipeline(name, **filters)
@@ -755,26 +857,25 @@ def download_pipeline_artifact(
         pipeline_run = pipeline.last_run
     else:
         pipeline_run = client.get_pipeline_run(name, **filters)
-    
+
     if pipeline_run is None:
         click.echo(f" {err} No pipeline run found for pipeline: {name}")
         sys.exit(1)
-    
+
     if isinstance(pipeline_run, models.ErrorResponse):
         click.echo(f" {err} Error fetching pipeline run:")
         echoerr(pipeline_run)
         sys.exit(1)
-    
+
     if client.download_pipeline_run_artifact(
-        pipeline_run.name, 
-        artifact_name,
-        step_name,
-        output
+        pipeline_run.name, artifact_name, step_name, output
     ):
-        click.echo(f" {chk} Artifact '{artifact_name}' from step '{step_name}' downloaded successfully!")
+        click.echo(
+            f" {chk} Artifact '{artifact_name}' from step '{step_name}' downloaded successfully!"
+        )
 
 
-@delete.command(name='pipeline', help='Delete PRAX Pipeline')
+@delete.command(name="pipeline", help="Delete PRAX Pipeline")
 @click.pass_context
 @name_argument
 @project_org_option
@@ -797,6 +898,7 @@ def delete_pipeline(ctx: click.Context, name: str, **filters):
             sys.exit(1)
         else:
             click.echo(f"{chk} Pipeline deleted successfully!")
+
 
 # @stop.command(name='pipeline', help='Stop PRAX Pipeline')
 # @click.pass_context

--- a/src/oceanum/cli/prax/workflows.py
+++ b/src/oceanum/cli/prax/workflows.py
@@ -25,7 +25,13 @@ def parse_parameters(parameters: list[str] | None) -> dict | None:
     params = {}
     if parameters is not None:
         for p in parameters:
-            key, value = p.split("=")
+            parts = p.split("=", 1)
+            if len(parts) != 2:
+                raise click.BadParameter(
+                    f"Parameter '{p}' is not in the expected 'key=value' format.",
+                    param_hint="'--parameter'",
+                )
+            key, value = parts
             params[key] = value
     return params or None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,30 +3,31 @@
 import os
 import tempfile
 from unittest.mock import patch
+
 from oceanum.cli.models import TokenResponse
-import pytest
-import oceanum.cli.prax
+
 tmpdir = tempfile.TemporaryDirectory()
-dir_patcher = patch('platformdirs.user_data_dir', return_value=tmpdir.name)
-active_org_patcher = patch.object(TokenResponse, 'active_org', return_value='test-org')
-email_patcher = patch.object(TokenResponse, 'email', return_value='test@test.com')
+dir_patcher = patch("platformdirs.user_data_dir", return_value=tmpdir.name)
+active_org_patcher = patch.object(TokenResponse, "active_org", return_value="test-org")
+email_patcher = patch.object(TokenResponse, "email", return_value="test@test.com")
+
 
 def pytest_sessionstart(session):
-    os.environ['OCEANUM_DOMAIN'] = 'oceanum.test'
+    os.environ["OCEANUM_DOMAIN"] = "oceanum.test"
     dir_patcher.start()
     TokenResponse(
-        access_token='123',
+        access_token="123",
         expires_in=3600,
-        token_type='Bearer',
-        domain='oceanum.test',
-        refresh_token='456'
+        token_type="Bearer",
+        domain="oceanum.test",
+        refresh_token="456",
     ).save()
     active_org_patcher.start()
     email_patcher.start()
-    
+
 
 def pytest_sessionfinish(session):
-    del os.environ['OCEANUM_DOMAIN']
+    del os.environ["OCEANUM_DOMAIN"]
     dir_patcher.stop()
     active_org_patcher.stop()
     email_patcher.stop()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,78 +1,86 @@
-from unittest import TestCase
-from pathlib import Path
 from datetime import datetime, timezone
-import requests
-from unittest.mock import patch, MagicMock
-from oceanum.cli.prax import main, project, route, user, models
-from oceanum.cli.prax.main import prax
-from oceanum.cli import main
-from oceanum.cli.models import ContextObject, TokenResponse, Auth0Config
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
 from click.testing import CliRunner
-from click.globals import get_current_context
+
+from oceanum.cli import main
+from oceanum.cli.prax import models
+from oceanum.cli.prax.main import prax
+
 
 class TestPRAXCommands(TestCase):
-
     def setUp(self) -> None:
         self.runner = CliRunner()
-        self.specfile = Path(__file__).parent / 'data/dpm-project.yaml'
+        self.specfile = Path(__file__).parent / "data/dpm-project.yaml"
         return super().setUp()
 
     def test_describe_help(self):
-        result = self.runner.invoke(prax, ['describe', '--help'])
+        result = self.runner.invoke(prax, ["describe", "--help"])
         assert result.exit_code == 0
-
 
     def test_describe_route(self):
         route = models.RouteSchema(
-            id='test-route-id',
-            name='test-route',
-            org='test-org',
-            display_name='test-route',
+            id="test-route-id",
+            name="test-route",
+            org="test-org",
+            display_name="test-route",
             created_at=datetime.now(tz=timezone.utc),
             updated_at=datetime.now(tz=timezone.utc),
-            project='test-project',
-            stage='test-stage',
-            tier='frontend',
-            status='active',
-            url='http://test-route',
+            project="test-project",
+            stage="test-stage",
+            tier="frontend",
+            status="active",
+            url="http://test-route",
         )
-        with patch('oceanum.cli.prax.client.PRAXClient.get_route', return_value=route) as mock_get:
-            result = self.runner.invoke(main, ['prax','describe','route','test-route'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_route", return_value=route
+        ) as mock_get:
+            result = self.runner.invoke(
+                main, ["prax", "describe", "route", "test-route"]
+            )
             assert result.exit_code == 0
-            mock_get.assert_called_once_with('test-route')
-    
+            mock_get.assert_called_once_with("test-route")
+
     def test_describe_route_not_found(self):
-        result = self.runner.invoke(main, ['prax','describe','route','test-route'])
+        result = self.runner.invoke(main, ["prax", "describe", "route", "test-route"])
         assert result.exit_code != 0
 
     def test_list_routes(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_routes') as mock_list:
-            result = self.runner.invoke(main, ['prax','list','routes'])
+        with patch("oceanum.cli.prax.client.PRAXClient.list_routes") as mock_list:
+            result = self.runner.invoke(main, ["prax", "list", "routes"])
             assert result.exit_code == 0
             mock_list.assert_called_once_with()
-    
+
     def test_list_routes_apps(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_routes') as mock_list:
-            result = self.runner.invoke(main, ['prax','list','routes','--tier','frontend'])
+        with patch("oceanum.cli.prax.client.PRAXClient.list_routes") as mock_list:
+            result = self.runner.invoke(
+                main, ["prax", "list", "routes", "--tier", "frontend"]
+            )
             assert result.exit_code == 0
-            mock_list.assert_called_once_with(tier='frontend')
-    
+            mock_list.assert_called_once_with(tier="frontend")
+
     def test_list_routes_services(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_routes') as mock_list:
-            result = self.runner.invoke(main, ['prax','list','routes','--tier','backend'])
+        with patch("oceanum.cli.prax.client.PRAXClient.list_routes") as mock_list:
+            result = self.runner.invoke(
+                main, ["prax", "list", "routes", "--tier", "backend"]
+            )
             print(result.output)
             assert result.exit_code == 0
-            
-            mock_list.assert_called_once_with(tier='backend')
+
+            mock_list.assert_called_once_with(tier="backend")
 
     def test_list_routes_open(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_routes') as mock_list:
-            result = self.runner.invoke(main, ['prax','list','routes','--open-access'])
+        with patch("oceanum.cli.prax.client.PRAXClient.list_routes") as mock_list:
+            result = self.runner.invoke(
+                main, ["prax", "list", "routes", "--open-access"]
+            )
             assert result.exit_code == 0
             mock_list.assert_called_once_with(open=True)
 
     def test_list_no_routes(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_routes') as mock_list:
+        with patch("oceanum.cli.prax.client.PRAXClient.list_routes") as mock_list:
             mock_list.return_value = []
-            result = self.runner.invoke(main, ['prax','list','routes'])
+            result = self.runner.invoke(main, ["prax", "list", "routes"])
             assert result.exit_code == 0

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,264 +1,378 @@
-from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
 from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import requests
 import yaml
-
-from pydantic import ValidationError
 from click.testing import CliRunner
-
-from datetime import datetime, timezone
+from pydantic import ValidationError
 
 from oceanum.cli import main as oceanum_main
-from oceanum.cli.prax import models, client
+from oceanum.cli.prax import client, models
 
 runner = CliRunner()
 
-good_specfile = Path(__file__).parent/'data/dpm-project.yaml'
+good_specfile = Path(__file__).parent / "data/dpm-project.yaml"
 with good_specfile.open() as f:
     project_schema = models.ProjectDetailsSchema(
-        id='test-project',
+        id="test-project",
         stages=[
             models.StageDetailsSchema(
-                id='test-stage',
+                id="test-stage",
                 updated_at=datetime.now().replace(tzinfo=timezone.utc),
-                name='test-stage',
-                status='healty',
+                name="test-stage",
+                status="healty",
                 resources=models.StageResourcesSchema(
-                    name='test-stage',
+                    name="test-stage",
                     pipelines=[],
                     tasks=[],
                     builds=[],
                     routes=[],
                     sources=[],
-                )
+                ),
             )
         ],
         last_revision=models.RevisionDetailsSchema(
-            id='test-revision',
+            id="test-revision",
             spec=models.ProjectSpec(**yaml.safe_load(f)),
             created_at=datetime.now().replace(tzinfo=timezone.utc),
             number=1,
-            status='active',
-            author='test-user',
+            status="active",
+            author="test-user",
         ),
-        name='test-project',
-        org='test-org',
-        owner='test-user',
+        name="test-project",
+        org="test-org",
+        owner="test-user",
         created_at=datetime.now().replace(tzinfo=timezone.utc),
-        description='test-description',
-        status='created',
+        description="test-description",
+        status="created",
     )
 
 
 class TestDeleteProject(TestCase):
-
     def test_delete_error(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project',
-            return_value=project_schema) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.delete_project',
-                return_value=models.ErrorResponse(detail='test-error')) as mock_delete:
-                result = runner.invoke(oceanum_main, ['prax', 'delete', 'project', 'test-project'], input='y')
-                assert 'Failed to delete' in result.output
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.delete_project",
+                return_value=models.ErrorResponse(detail="test-error"),
+            ) as mock_delete:
+                result = runner.invoke(
+                    oceanum_main,
+                    ["prax", "delete", "project", "test-project"],
+                    input="y",
+                )
+                assert "Failed to delete" in result.output
                 assert result.exit_code == 1
                 assert mock_delete.call_count == 1
 
     def test_delete_confirm_no(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project',
-            return_value=project_schema) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.delete_project') as mock_delete:
-                result = runner.invoke(oceanum_main, ['prax', 'delete', 'project', 'test-project'], input='n')
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.delete_project"
+            ) as mock_delete:
+                result = runner.invoke(
+                    oceanum_main,
+                    ["prax", "delete", "project", "test-project"],
+                    input="n",
+                )
                 assert result.exit_code == 1
                 assert mock_delete.call_count == 0
-                assert 'Aborted!' in result.output
+                assert "Aborted!" in result.output
 
     def test_delete_project_not_found(self):
         response = MagicMock(status_code=404)
-        response.json.return_value = {'detail': 'not found!'}
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError('404')
-        with patch('requests.request', return_value=response) as mock_request:
-            result = runner.invoke(oceanum_main, ['prax', 'delete', 'project', 'some-random-project'])
+        response.json.return_value = {"detail": "not found!"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+        with patch("requests.request", return_value=response) as mock_request:
+            result = runner.invoke(
+                oceanum_main, ["prax", "delete", "project", "some-random-project"]
+            )
             assert result.exit_code == 1
             assert mock_request.call_count == 1
-            assert 'not found!' in result.output
+            assert "not found!" in result.output
 
     def test_delete_existing_project_error(self):
         response = MagicMock(status_code=403)
-        response.json.return_value = {'detail': 'Forbidden!'}
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError('403')
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=project_schema) as mock_get:
-            with patch('requests.request', return_value=response) as mock_request:
-                result = runner.invoke(oceanum_main, ['prax', 'delete', 'project', 'test-project'], input='y')
+        response.json.return_value = {"detail": "Forbidden!"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("403")
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch("requests.request", return_value=response) as mock_request:
+                result = runner.invoke(
+                    oceanum_main,
+                    ["prax", "delete", "project", "test-project"],
+                    input="y",
+                )
                 assert result.exit_code == 1
                 assert mock_request.call_count == 1
-                assert 'Forbidden!' in result.output
+                assert "Forbidden!" in result.output
 
     def test_delete_project(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project',
-            return_value=project_schema) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.delete_project') as mock_delete:
-                result = runner.invoke(oceanum_main, ['prax', 'delete', 'project', 'test-project'], input='y')
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.delete_project"
+            ) as mock_delete:
+                result = runner.invoke(
+                    oceanum_main,
+                    ["prax", "delete", "project", "test-project"],
+                    input="y",
+                )
                 assert result.exit_code == 0
                 assert mock_delete.call_count == 1
-                assert 'removed shortly' in result.output
+                assert "removed shortly" in result.output
+
 
 class TestListProject(TestCase):
-
     def test_list_error(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_projects',
-            return_value=models.ErrorResponse(detail='test-error')) as mock_list:
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'projects'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_projects",
+            return_value=models.ErrorResponse(detail="test-error"),
+        ) as mock_list:
+            result = runner.invoke(oceanum_main, ["prax", "list", "projects"])
             assert result.exit_code == 1
-            assert 'Could not list' in result.output
+            assert "Could not list" in result.output
             mock_list.assert_called_once_with()
 
     def test_list_project_not_found(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_projects', return_value=[]) as mock_list:
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'projects'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_projects", return_value=[]
+        ) as mock_list:
+            result = runner.invoke(oceanum_main, ["prax", "list", "projects"])
             assert result.exit_code == 1
-            assert 'No projects found!' in result.output
+            assert "No projects found!" in result.output
             mock_list.assert_called_once_with()
-
 
     def test_list_project(self):
         projects = [
             models.ProjectDetailsSchema(
-                id='test-project',
+                id="test-project",
                 stages=[],
-                name='test-project',
-                org='test-org',
-                owner='test-user',
+                name="test-project",
+                org="test-org",
+                owner="test-user",
                 created_at=datetime.now().replace(tzinfo=timezone.utc),
-                description='test-description',
-                status='healthy',
+                description="test-description",
+                status="healthy",
             ),
         ]
 
-        with patch('oceanum.cli.prax.client.PRAXClient.list_projects', return_value=projects) as mock_list:
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'projects'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_projects", return_value=projects
+        ) as mock_list:
+            result = runner.invoke(oceanum_main, ["prax", "list", "projects"])
             assert result.exit_code == 0
             mock_list.assert_called_once_with()
 
 
 class TestValidateProject(TestCase):
     def setUp(self) -> None:
-        self.specfile = Path(__file__).parent/'data/dpm-project.yaml'
+        self.specfile = Path(__file__).parent / "data/dpm-project.yaml"
         self.project_spec = client.PRAXClient.load_spec(str(self.specfile))
         return super().setUp()
 
     def test_validation_error_no_file(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.validate') as mock_validate:
-            result = runner.invoke(oceanum_main, ['prax', 'validate', str('randomfile.yaml')])
+        with patch("oceanum.cli.prax.client.PRAXClient.validate") as mock_validate:
+            result = runner.invoke(
+                oceanum_main, ["prax", "validate", str("randomfile.yaml")]
+            )
             assert result.exit_code > 0
-            assert 'does not exist' in result.output
+            assert "does not exist" in result.output
 
     def test_validation_error_badspec(self):
         bad_spec = {
-            'name': 'my-project',
-            'org': 'test-org',
+            "name": "my-project",
+            "org": "test-org",
         }
-        with patch('oceanum.cli.prax.client.PRAXClient.validate') as mock_validate:
+        with patch("oceanum.cli.prax.client.PRAXClient.validate") as mock_validate:
             try:
-                models.ProjectSpec(**bad_spec) # type: ignore
+                models.ProjectSpec(**bad_spec)  # type: ignore
             except ValidationError as e:
-                mock_validate.return_value = models.ErrorResponse(detail=e.errors()) # type: ignore
-            result = runner.invoke(oceanum_main, ['prax', 'validate', str(self.specfile)], catch_exceptions=True)
+                mock_validate.return_value = models.ErrorResponse(detail=e.errors())  # type: ignore
+            result = runner.invoke(
+                oceanum_main,
+                ["prax", "validate", str(self.specfile)],
+                catch_exceptions=True,
+            )
             assert result.exit_code > 0
-            assert 'Extra inputs are not permitted' in result.output
+            assert "Extra inputs are not permitted" in result.output
 
     def test_validate_specfile(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.validate') as mock_validate:
-            result = runner.invoke(oceanum_main, ['prax','validate', str(self.specfile)], catch_exceptions=True)
+        with patch("oceanum.cli.prax.client.PRAXClient.validate") as mock_validate:
+            result = runner.invoke(
+                oceanum_main,
+                ["prax", "validate", str(self.specfile)],
+                catch_exceptions=True,
+            )
             assert result.exit_code == 0
             mock_validate.assert_called_once_with(str(self.specfile))
 
 
 class TestUpdateProject(TestCase):
     def test_update_active(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=project_schema) as mock_get:
-            patch_resp = project_schema.model_copy(update={'active': False})
-            with patch('oceanum.cli.prax.client.PRAXClient.patch_project', return_value=patch_resp) as mock_update:
-                result = runner.invoke(oceanum_main, ['prax', 'update', 'project', 'test-project', '--active', '0'])
-                assert 'updated' in result.output
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            patch_resp = project_schema.model_copy(update={"active": False})
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.patch_project",
+                return_value=patch_resp,
+            ) as mock_update:
+                result = runner.invoke(
+                    oceanum_main,
+                    ["prax", "update", "project", "test-project", "--active", "0"],
+                )
+                assert "updated" in result.output
 
     def test_update_description(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=project_schema) as mock_get:
-            patch_resp = project_schema.model_copy(update={'description': 'new-description'})
-            with patch('oceanum.cli.prax.client.PRAXClient.patch_project', return_value=patch_resp) as mock_update:
-                result = runner.invoke(oceanum_main, ['prax', 'update', 'project', 'test-project', '--description', 'new-description'])
-                assert 'updated' in result.output
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            patch_resp = project_schema.model_copy(
+                update={"description": "new-description"}
+            )
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.patch_project",
+                return_value=patch_resp,
+            ) as mock_update:
+                result = runner.invoke(
+                    oceanum_main,
+                    [
+                        "prax",
+                        "update",
+                        "project",
+                        "test-project",
+                        "--description",
+                        "new-description",
+                    ],
+                )
+                assert "updated" in result.output
 
     def test_update_error(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=project_schema) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.patch_project', return_value=models.ErrorResponse(detail='test-error')) as mock_update:
-                result = runner.invoke(oceanum_main, ['prax', 'update', 'project', 'test-project', '--active', '0'])
-                assert 'Failed to update' in result.output
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.patch_project",
+                return_value=models.ErrorResponse(detail="test-error"),
+            ) as mock_update:
+                result = runner.invoke(
+                    oceanum_main,
+                    ["prax", "update", "project", "test-project", "--active", "0"],
+                )
+                assert "Failed to update" in result.output
                 assert result.exit_code == 1
 
 
 class TestDeployProject(TestCase):
-
     def setUp(self) -> None:
-        self.specfile = str(Path(__file__).parent/'data/dpm-project.yaml')
-        self.bad_specfile = str(Path(__file__).parent/'data/bad-project.yaml')
+        self.specfile = str(Path(__file__).parent / "data/dpm-project.yaml")
+        self.bad_specfile = str(Path(__file__).parent / "data/bad-project.yaml")
         return super().setUp()
 
     def tearDown(self) -> None:
         return super().tearDown()
 
     def test_deploy_help(self):
-        result = runner.invoke(oceanum_main, ['prax','deploy', '--help'])
+        result = runner.invoke(oceanum_main, ["prax", "deploy", "--help"])
         assert result.exit_code == 0
 
     def test_deploy_empty(self):
-        result = runner.invoke(oceanum_main, ['prax','deploy'])
+        result = runner.invoke(oceanum_main, ["prax", "deploy"])
         assert result.exit_code != 0
-        assert 'Missing argument' in result.output
+        assert "Missing argument" in result.output
 
     def test_deploy_specfile_not_found(self):
-        result = runner.invoke(oceanum_main, ['prax','deploy', 'randomfile.yaml'])
+        result = runner.invoke(oceanum_main, ["prax", "deploy", "randomfile.yaml"])
         assert result.exit_code != 0
-        assert 'does not exist' in result.output
+        assert "does not exist" in result.output
 
     def test_deploy_specfile_error(self):
-        result = runner.invoke(oceanum_main, ['prax','deploy', str(self.bad_specfile)])
+        result = runner.invoke(oceanum_main, ["prax", "deploy", str(self.bad_specfile)])
         assert result.exit_code != 0
-        assert 'Extra inputs are not permitted' in result.output
+        assert "Extra inputs are not permitted" in result.output
 
     def test_deploy_specfile_no_args(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project',
-            return_value=project_schema
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
         ) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.deploy_project',
-                return_value=project_schema
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.deploy_project",
+                return_value=project_schema,
             ) as mock_deploy:
                 result = runner.invoke(
-                    oceanum_main, ['prax','deploy', str(self.specfile),'--wait=0']
+                    oceanum_main, ["prax", "deploy", str(self.specfile), "--wait=0"]
                 )
-                assert 'created successfully' in result.output
+                assert "created successfully" in result.output
                 assert result.exit_code == 0
                 assert mock_deploy.call_args[0][0].name == project_schema.name
 
     def test_deploy_specfile_with_secrets(self):
-        secret_overlay = 'test-secret:token=123456'
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=project_schema) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.deploy_project', return_value=project_schema) as mock_deploy:
+        secret_overlay = "test-secret:token=123456"
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.deploy_project",
+                return_value=project_schema,
+            ) as mock_deploy:
                 result = runner.invoke(
-                    oceanum_main, ['prax','deploy', str(self.specfile),'-s', secret_overlay,'--wait=0']
+                    oceanum_main,
+                    [
+                        "prax",
+                        "deploy",
+                        str(self.specfile),
+                        "-s",
+                        secret_overlay,
+                        "--wait=0",
+                    ],
                 )
                 assert result.exit_code == 0
-                assert mock_deploy.call_args[0][0].resources.secrets[0].data.root['token'] == '123456'
+                assert (
+                    mock_deploy.call_args[0][0].resources.secrets[0].data.root["token"]
+                    == "123456"
+                )
 
     def test_deploy_with_org_member(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=project_schema) as mock_get:
-            with patch('oceanum.cli.prax.client.PRAXClient.deploy_project', return_value=project_schema) as mock_deploy:
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=project_schema,
+        ) as mock_get:
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.deploy_project",
+                return_value=project_schema,
+            ) as mock_deploy:
                 result = runner.invoke(
-                    oceanum_main, ['prax','deploy', str(self.specfile),'--org','test','--wait=0','--user=test@test.com']
+                    oceanum_main,
+                    [
+                        "prax",
+                        "deploy",
+                        str(self.specfile),
+                        "--org",
+                        "test",
+                        "--wait=0",
+                        "--user=test@test.com",
+                    ],
                 )
                 assert result.exit_code == 0
-                assert mock_deploy.call_args[0][0].user_ref.root == 'test'
-                assert mock_deploy.call_args[0][0].member_ref == 'test@test.com'
+                assert mock_deploy.call_args[0][0].user_ref.root == "test"
+                assert mock_deploy.call_args[0][0].member_ref == "test@test.com"
 
 
 class TestDescribeProject(TestCase):
@@ -266,120 +380,150 @@ class TestDescribeProject(TestCase):
         self.full_schema = models.ProjectDetailsSchema(
             stages=[
                 models.StageDetailsSchema(
-                    id='test-stage',
+                    id="test-stage",
                     updated_at=datetime.now().replace(tzinfo=timezone.utc),
-                    name='test-stage',
-                    status='healthy',
+                    name="test-stage",
+                    status="healthy",
                     resources=models.StageResourcesSchema(
-                        name='test-stage',
+                        name="test-stage",
                         pipelines=[],
                         tasks=[],
                         sources=[
                             models.SourceSchema(
-                                id='test-source',
-                                name='test-source',
-                                org='test-org',
+                                id="test-source",
+                                name="test-source",
+                                org="test-org",
                                 created_at=datetime.now().replace(tzinfo=timezone.utc),
                                 updated_at=datetime.now().replace(tzinfo=timezone.utc),
-                                project='test-project',
-                                stage='test-stage',
-                                status='active',
-                                source_type='github',
-                                repository='test-repo',
+                                project="test-project",
+                                stage="test-stage",
+                                status="active",
+                                source_type="github",
+                                repository="test-repo",
                             )
                         ],
                         builds=[
                             models.BuildSchema(
-                                id='test-build',
-                                org='test-org',
-                                project='test-project',
-                                name='test-build',
-                                stage='test-stage',
+                                id="test-build",
+                                org="test-org",
+                                project="test-project",
+                                name="test-build",
+                                stage="test-stage",
                                 created_at=datetime.now().replace(tzinfo=timezone.utc),
                                 updated_at=datetime.now().replace(tzinfo=timezone.utc),
                             )
                         ],
                         routes=[
                             models.RouteSchema(
-                                id='test-route',
-                                name='test-route',
-                                org='test-org',
-                                display_name='test-route',
+                                id="test-route",
+                                name="test-route",
+                                org="test-org",
+                                display_name="test-route",
                                 created_at=datetime.now().replace(tzinfo=timezone.utc),
                                 updated_at=datetime.now().replace(tzinfo=timezone.utc),
-                                project='test-project',
-                                stage='test-stage',
-                                status='active',
-                                url='http://test-route',
-                                custom_domains=['test-domain'],
+                                project="test-project",
+                                stage="test-stage",
+                                status="active",
+                                url="http://test-route",
+                                custom_domains=["test-domain"],
                             )
                         ],
-                    )
+                    ),
                 )
             ],
             last_revision=models.RevisionDetailsSchema(
-                id='test-revision',
+                id="test-revision",
                 spec=models.ProjectSpec(
-                    name='test-project',
-                    userRef=models.UserRef('test-user'),
-                    memberRef='test-member@member.ref',
+                    name="test-project",
+                    userRef=models.UserRef("test-user"),
+                    memberRef="test-member@member.ref",
                 ),
                 created_at=datetime.now().replace(tzinfo=timezone.utc),
                 number=1,
-                status='active',
-                author='test-user',
+                status="active",
+                author="test-user",
             ),
-            id='test-project',
-            name='test-project',
-            org='test-org',
-            owner='test-user',
+            id="test-project",
+            name="test-project",
+            org="test-org",
+            owner="test-user",
             created_at=datetime.now().replace(tzinfo=timezone.utc),
-            description='test-description',
+            description="test-description",
         )
 
     def test_describe_help(self):
-        result = runner.invoke(oceanum_main, ['prax', 'describe', 'project', '--help'])
+        result = runner.invoke(oceanum_main, ["prax", "describe", "project", "--help"])
         assert result.exit_code == 0
 
     def test_describe_project_not_found(self):
         response = MagicMock(status_code=404)
-        response.json.return_value = {'detail': 'not found!'}
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError('404')
-        with patch('requests.request', return_value=response) as mock_request:
-            result = runner.invoke(oceanum_main, ['prax', 'describe', 'project', 'some-random-project'])
+        response.json.return_value = {"detail": "not found!"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+        with patch("requests.request", return_value=response) as mock_request:
+            result = runner.invoke(
+                oceanum_main, ["prax", "describe", "project", "some-random-project"]
+            )
             assert result.exit_code == 1
             assert mock_request.call_count == 1
-            assert 'not found!' in result.output
+            assert "not found!" in result.output
 
     def test_describe_project(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=self.full_schema) as mock_get:
-            result = runner.invoke(oceanum_main, ['prax', 'describe', 'project', 'test-project'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=self.full_schema,
+        ) as mock_get:
+            result = runner.invoke(
+                oceanum_main, ["prax", "describe", "project", "test-project"]
+            )
             assert result.exit_code == 0
-            assert 'healthy' in result.output
+            assert "healthy" in result.output
 
     def test_describe_project_show_spec(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=self.full_schema) as mock_get:
-            result = runner.invoke(oceanum_main, ['prax', 'describe', 'project', 'test-project', '--show-spec'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=self.full_schema,
+        ) as mock_get:
+            result = runner.invoke(
+                oceanum_main,
+                ["prax", "describe", "project", "test-project", "--show-spec"],
+            )
             assert result.exit_code == 0
-            assert 'test-project' in result.output
+            assert "test-project" in result.output
 
     def test_describe_project_only_spec(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.get_project', return_value=self.full_schema) as mock_get:
-            result = runner.invoke(oceanum_main, ['prax', 'describe', 'project', 'test-project', '--only-spec'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_project",
+            return_value=self.full_schema,
+        ) as mock_get:
+            result = runner.invoke(
+                oceanum_main,
+                ["prax", "describe", "project", "test-project", "--only-spec"],
+            )
             assert result.exit_code == 0
-            assert 'test-project' in result.output
+            assert "test-project" in result.output
+
 
 class TestAllowProject(TestCase):
     def test_allow_help(self):
-        result = runner.invoke(oceanum_main, ['prax', 'allow', 'project', '--help'])
+        result = runner.invoke(oceanum_main, ["prax", "allow", "project", "--help"])
         assert result.exit_code == 0
 
     def test_allow_project_not_found(self):
         response = MagicMock(status_code=404)
-        response.json.return_value = {'detail': 'not found!'}
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError('404')
-        with patch('requests.request', return_value=response) as mock_request:
-            result = runner.invoke(oceanum_main, ['prax', 'allow', 'project', 'some-random-project','--user','some-user'])
+        response.json.return_value = {"detail": "not found!"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+        with patch("requests.request", return_value=response) as mock_request:
+            result = runner.invoke(
+                oceanum_main,
+                [
+                    "prax",
+                    "allow",
+                    "project",
+                    "some-random-project",
+                    "--user",
+                    "some-user",
+                ],
+            )
             print(result.output)
             assert result.exit_code == 1
             assert mock_request.call_count == 1
@@ -389,101 +533,134 @@ class TestAllowProject(TestCase):
             users=[],
             groups=[],
         )
-        with patch.object(client.PRAXClient, 'get_project', return_value=project_schema) as mock_request:
-            with patch.object(client.PRAXClient, '_request', return_value=(post_response, None)) as mock_request:
-                result = runner.invoke(oceanum_main, ['prax', 'allow', 'project', 'test-project','--user','some-user','--change=True'])
+        with patch.object(
+            client.PRAXClient, "get_project", return_value=project_schema
+        ) as mock_request:
+            with patch.object(
+                client.PRAXClient, "_request", return_value=(post_response, None)
+            ) as mock_request:
+                result = runner.invoke(
+                    oceanum_main,
+                    [
+                        "prax",
+                        "allow",
+                        "project",
+                        "test-project",
+                        "--user",
+                        "some-user",
+                        "--change=True",
+                    ],
+                )
                 assert result.exit_code == 0
+
 
 timestamp = datetime.now(tz=timezone.utc).isoformat()
 
+
 class TestListSources(TestCase):
     def test_list_sources_help(self):
-        result = runner.invoke(oceanum_main, ['prax', 'list', 'sources', '--help'])
+        result = runner.invoke(oceanum_main, ["prax", "list", "sources", "--help"])
         assert result.exit_code == 0
 
     def test_list_sources_success(self):
-        sources_response = [{
-            "name": "test-source",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "source_type": "git",
-            "repository": "https://github.com/test/repo",
-            "status": "active"
-        }]
+        sources_response = [
+            {
+                "name": "test-source",
+                "project": "test-project",
+                "stage": "dev",
+                "org": "test-org",
+                "created_at": timestamp,
+                "updated_at": timestamp,
+                "source_type": "git",
+                "repository": "https://github.com/test/repo",
+                "status": "active",
+            }
+        ]
 
-        with patch('oceanum.cli.prax.client.PRAXClient.list_sources',
-                  return_value=sources_response) as mock_list:
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'sources'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_sources",
+            return_value=sources_response,
+        ) as mock_list:
+            result = runner.invoke(oceanum_main, ["prax", "list", "sources"])
             assert result.exit_code == 0
-            assert 'test-source' in result.output
+            assert "test-source" in result.output
             mock_list.assert_called_once_with(
-                search=None,
-                project=None,
-                org=None,
-                user=None,
-                status=None
+                search=None, project=None, org=None, user=None, status=None
             )
 
     def test_list_sources_with_filters(self):
-        sources_response = [{
-            "name": "test-source",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "source_type": "git",
-            "repository": "https://github.com/test/repo",
-            "status": "active"
-        }]
+        sources_response = [
+            {
+                "name": "test-source",
+                "project": "test-project",
+                "stage": "dev",
+                "org": "test-org",
+                "created_at": timestamp,
+                "updated_at": timestamp,
+                "source_type": "git",
+                "repository": "https://github.com/test/repo",
+                "status": "active",
+            }
+        ]
 
-        with patch('oceanum.cli.prax.client.PRAXClient.list_sources',
-                  return_value=sources_response) as mock_list:
-            result = runner.invoke(oceanum_main, [
-                'prax', 'list', 'sources',
-                '--project', 'test-project',
-                '--org', 'test-org',
-                '--user', 'test@user.com',
-                '--status', 'active',
-                '--search', 'test'
-            ])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_sources",
+            return_value=sources_response,
+        ) as mock_list:
+            result = runner.invoke(
+                oceanum_main,
+                [
+                    "prax",
+                    "list",
+                    "sources",
+                    "--project",
+                    "test-project",
+                    "--org",
+                    "test-org",
+                    "--user",
+                    "test@user.com",
+                    "--status",
+                    "active",
+                    "--search",
+                    "test",
+                ],
+            )
             assert result.exit_code == 0
-            assert 'test-source' in result.output
+            assert "test-source" in result.output
             mock_list.assert_called_once_with(
-                search='test',
-                project='test-project',
-                org='test-org',
-                user='test@user.com',
-                status='active'
+                search="test",
+                project="test-project",
+                org="test-org",
+                user="test@user.com",
+                status="active",
             )
 
     def test_list_sources_empty(self):
-        with patch('oceanum.cli.prax.client.PRAXClient.list_sources',
-                  return_value=[]) as mock_list:
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'sources'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_sources", return_value=[]
+        ) as mock_list:
+            result = runner.invoke(oceanum_main, ["prax", "list", "sources"])
             assert result.exit_code == 1
-            assert 'No sources found!' in result.output
+            assert "No sources found!" in result.output
 
     def test_list_sources_error(self):
         error_response = models.ErrorResponse(
-            status_code=500,
-            detail="Internal server error"
+            status_code=500, detail="Internal server error"
         )
-        with patch('oceanum.cli.prax.client.PRAXClient.list_sources',
-                  return_value=error_response) as mock_list:
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'sources'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.list_sources",
+            return_value=error_response,
+        ) as mock_list:
+            result = runner.invoke(oceanum_main, ["prax", "list", "sources"])
             assert result.exit_code == 1
-            assert 'Could not list sources!' in result.output
+            assert "Could not list sources!" in result.output
 
     def test_list_sources_authentication(self):
         response = MagicMock(status_code=401)
-        response.json.return_value = {'detail': 'Not authenticated'}
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError('401')
+        response.json.return_value = {"detail": "Not authenticated"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("401")
 
-        with patch('requests.request', return_value=response):
-            result = runner.invoke(oceanum_main, ['prax', 'list', 'sources'])
+        with patch("requests.request", return_value=response):
+            result = runner.invoke(oceanum_main, ["prax", "list", "sources"])
             assert result.exit_code == 1
-            assert 'Not authenticated' in result.output
+            assert "Not authenticated" in result.output

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,55 +1,54 @@
-from unittest import TestCase
-from unittest.mock import patch, MagicMock
-
 from datetime import datetime, timezone
-import requests
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
+import requests
 from click.testing import CliRunner
 
-
 from oceanum.cli import main
-from oceanum.cli.prax import models, client
+from oceanum.cli.prax import client, models
 
 runner = CliRunner()
 
 route_schema = models.RouteSchema(
-    id='test-route-id',
-    name='test-route',
-    org='test-org',
-    display_name='test-route',
+    id="test-route-id",
+    name="test-route",
+    org="test-org",
+    display_name="test-route",
     created_at=datetime.now(tz=timezone.utc),
     updated_at=datetime.now(tz=timezone.utc),
-    project='test-project',
-    stage='test-stage',
-    status='active',
-    url='http://test-route',
+    project="test-project",
+    stage="test-stage",
+    status="active",
+    url="http://test-route",
 )
 
-class TestAllowProject(TestCase):
 
+class TestAllowProject(TestCase):
     def test_list_notebooks(self):
         response = MagicMock(status_code=200)
         response.json.return_value = [
-            route_schema.model_copy(
-                update={'notebook':True}
-            ).model_dump()
+            route_schema.model_copy(update={"notebook": True}).model_dump()
         ]
-        with patch('requests.request', return_value=response) as mock_request:
-            result = runner.invoke(main, ['prax', 'list', 'notebooks'])
+        with patch("requests.request", return_value=response) as mock_request:
+            result = runner.invoke(main, ["prax", "list", "notebooks"])
             print(result.output)
             assert result.exit_code == 0
-            assert 'test-route' in result.output
-    
+            assert "test-route" in result.output
+
     def test_allow_help(self):
-        result = runner.invoke(main, ['prax', 'allow', 'project', '--help'])
+        result = runner.invoke(main, ["prax", "allow", "project", "--help"])
         assert result.exit_code == 0
 
     def test_allow_route_not_found(self):
         response = MagicMock(status_code=404)
-        response.json.return_value = {'detail': 'not found!'}
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError('404')
-        with patch('requests.request', return_value=response) as mock_request:
-            result = runner.invoke(main, ['prax', 'allow', 'route', 'some-random-route','--user','some-user'])
+        response.json.return_value = {"detail": "not found!"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+        with patch("requests.request", return_value=response) as mock_request:
+            result = runner.invoke(
+                main,
+                ["prax", "allow", "route", "some-random-route", "--user", "some-user"],
+            )
             assert result.exit_code == 1
             assert mock_request.call_count == 1
 
@@ -58,7 +57,22 @@ class TestAllowProject(TestCase):
             users=[],
             groups=[],
         )
-        with patch.object(client.PRAXClient, 'get_route', return_value=route_schema) as mock_request:
-            with patch.object(client.PRAXClient, '_request', return_value=(post_response, None)) as mock_request:
-                result = runner.invoke(main, ['prax', 'allow', 'route', 'test-route','--user','some-user','--change=True'])
+        with patch.object(
+            client.PRAXClient, "get_route", return_value=route_schema
+        ) as mock_request:
+            with patch.object(
+                client.PRAXClient, "_request", return_value=(post_response, None)
+            ) as mock_request:
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "allow",
+                        "route",
+                        "test-route",
+                        "--user",
+                        "some-user",
+                        "--change=True",
+                    ],
+                )
                 assert result.exit_code == 0

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -4,144 +4,157 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from oceanum.cli import main
-from oceanum.cli.prax import models, client, user
+from oceanum.cli.prax import client, models
 
 runner = CliRunner()
 
 
 class TestUser(TestCase):
-
     def test_create_user_secret_help(self):
-        result = runner.invoke(main, ['prax', 'create', 'user-secret', '--help'])
+        result = runner.invoke(main, ["prax", "create", "user-secret", "--help"])
         assert result.exit_code == 0
 
     def test_create_user_secret(self):
-        user_get_response = [models.UserSchema(**{
-            'username': 'test-user',
-            'email': 'test-user@test.com',
-            'token': 'test-token',
-            'deployable_orgs': ['test-org'],
-            'admin_orgs': ['test-org'],
-            'current_org': {
-                'name': 'test-org',
-                'projects': ['test-project'],
-                'tier': {
-                    'name': 'test-tier',
-                },
-                'usage': {
-                    'name': 'usage',
-                },
-                'resources': [],
-            },
-            'projects': [],
-        })]
+        user_get_response = [
+            models.UserSchema(
+                **{
+                    "username": "test-user",
+                    "email": "test-user@test.com",
+                    "token": "test-token",
+                    "deployable_orgs": ["test-org"],
+                    "admin_orgs": ["test-org"],
+                    "current_org": {
+                        "name": "test-org",
+                        "projects": ["test-project"],
+                        "tier": {
+                            "name": "test-tier",
+                        },
+                        "usage": {
+                            "name": "usage",
+                        },
+                        "resources": [],
+                    },
+                    "projects": [],
+                }
+            )
+        ]
         create_response = models.SecretSpec(
-            name='test-secret',
-            description='test-secret',
-            data=models.SecretData(root={'key': models.SecretStr('value')}),
+            name="test-secret",
+            description="test-secret",
+            data=models.SecretData(root={"key": models.SecretStr("value")}),
         )
 
-        with patch.object(client.PRAXClient, 'get_users') as get_users_mock:
+        with patch.object(client.PRAXClient, "get_users") as get_users_mock:
             get_users_mock.return_value = user_get_response
-            with patch.object(client.PRAXClient, '_request') as mock_request:
+            with patch.object(client.PRAXClient, "_request") as mock_request:
                 mock_request.return_value = (create_response, None)
-                result = runner.invoke(main, [
-                    'prax', 'create', 'user-secret', 'test-secret', '--data', 'key=value'
-                ])
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "create",
+                        "user-secret",
+                        "test-secret",
+                        "--data",
+                        "key=value",
+                    ],
+                )
                 print(result.exc_info)
-                assert 'test-secret' in result.output
+                assert "test-secret" in result.output
 
     def test_describe_user(self):
         response = [
-            models.UserSchema(**
-            {
-                "id": "test-user-id",
-                'username': 'test-user',
-                'email': 'test-user@test.com',
-                'token': 'test-token',
-                'all_orgs': ['test-org'],
-                'deployable_orgs': ['test-org'],
-                'admin_orgs': ['test-org'],
-                'projects': ['test-project'],
-                'current_org': {
-                    'name': 'test-org',
-                    'projects': ['test-project'],
-                    "tier": {
-                        "max_cpu": 32000,
-                        "max_cpu_per_service": 4000,
-                        "max_cpu_per_task": 32000,
-                        "max_memory_per_service": 32000,
-                        "max_memory_per_task": 32000,
-                        "max_memory": 128000,
-                        "max_gpu": 0,
-                        "max_ephemeral_storage": 100000,
-                        "max_ephemeral_storage_per_service": 50000,
-                        "max_ephemeral_storage_per_task": 50000,
-                        "max_concurrent_workflows": 0,
-                        "max_persistent_storage": 100000,
-                        "max_persistent_volume_size": 10000,
-                        "max_persistent_volumes": 10,
-                        "max_projects": 50,
-                        "max_stages": 100,
-                        "max_builds": 100,
-                        "max_pipelines": 100,
-                        "max_tasks": 100,
-                        "max_secrets": 100,
-                        "max_images": 100,
-                        "max_sources": 100,
-                        "max_notebooks": 10,
-                        "max_services": 10,
-                        "max_configmaps": 100,
-                        "name": "basic"
+            models.UserSchema(
+                **{
+                    "id": "test-user-id",
+                    "username": "test-user",
+                    "email": "test-user@test.com",
+                    "token": "test-token",
+                    "all_orgs": ["test-org"],
+                    "deployable_orgs": ["test-org"],
+                    "admin_orgs": ["test-org"],
+                    "projects": ["test-project"],
+                    "current_org": {
+                        "name": "test-org",
+                        "projects": ["test-project"],
+                        "tier": {
+                            "max_cpu": 32000,
+                            "max_cpu_per_service": 4000,
+                            "max_cpu_per_task": 32000,
+                            "max_memory_per_service": 32000,
+                            "max_memory_per_task": 32000,
+                            "max_memory": 128000,
+                            "max_gpu": 0,
+                            "max_ephemeral_storage": 100000,
+                            "max_ephemeral_storage_per_service": 50000,
+                            "max_ephemeral_storage_per_task": 50000,
+                            "max_concurrent_workflows": 0,
+                            "max_persistent_storage": 100000,
+                            "max_persistent_volume_size": 10000,
+                            "max_persistent_volumes": 10,
+                            "max_projects": 50,
+                            "max_stages": 100,
+                            "max_builds": 100,
+                            "max_pipelines": 100,
+                            "max_tasks": 100,
+                            "max_secrets": 100,
+                            "max_images": 100,
+                            "max_sources": 100,
+                            "max_notebooks": 10,
+                            "max_services": 10,
+                            "max_configmaps": 100,
+                            "name": "basic",
                         },
-                    "usage": {
-                        "max_cpu": 0,
-                        "max_cpu_per_service": 0,
-                        "max_cpu_per_task": 0,
-                        "max_memory_per_service": 0,
-                        "max_memory_per_task": 0,
-                        "max_memory": 0,
-                        "max_gpu": 0,
-                        "max_ephemeral_storage": 0,
-                        "max_ephemeral_storage_per_service": 0,
-                        "max_ephemeral_storage_per_task": 0,
-                        "max_concurrent_workflows": 0,
-                        "max_persistent_storage": 0,
-                        "max_persistent_volume_size": 0,
-                        "max_persistent_volumes": 0,
-                        "max_projects": 0,
-                        "max_stages": 0,
-                        "max_builds": 0,
-                        "max_pipelines": 0,
-                        "max_tasks": 0,
-                        "max_secrets": 0,
-                        "max_images": 0,
-                        "max_sources": 0,
-                        "max_notebooks": 0,
-                        "max_services": 0,
-                        "max_configmaps": 0,
-                        "name": "usage"
+                        "usage": {
+                            "max_cpu": 0,
+                            "max_cpu_per_service": 0,
+                            "max_cpu_per_task": 0,
+                            "max_memory_per_service": 0,
+                            "max_memory_per_task": 0,
+                            "max_memory": 0,
+                            "max_gpu": 0,
+                            "max_ephemeral_storage": 0,
+                            "max_ephemeral_storage_per_service": 0,
+                            "max_ephemeral_storage_per_task": 0,
+                            "max_concurrent_workflows": 0,
+                            "max_persistent_storage": 0,
+                            "max_persistent_volume_size": 0,
+                            "max_persistent_volumes": 0,
+                            "max_projects": 0,
+                            "max_stages": 0,
+                            "max_builds": 0,
+                            "max_pipelines": 0,
+                            "max_tasks": 0,
+                            "max_secrets": 0,
+                            "max_images": 0,
+                            "max_sources": 0,
+                            "max_notebooks": 0,
+                            "max_services": 0,
+                            "max_configmaps": 0,
+                            "name": "usage",
+                        },
+                        "resources": [
+                            {
+                                "org": "test-org",
+                                "name": "test-secret",
+                                "created_at": "2021-09-09T12:00:00Z",
+                                "updated_at": "2021-09-09T12:00:00Z",
+                                "resource_type": "secret",
+                                "spec": {
+                                    "name": "test-secret",
+                                    "description": "test-secret",
+                                    "data": {"key": "value"},
+                                },
+                            }
+                        ],
                     },
-                    'resources': [{
-                        'org': 'test-org',
-                        'name': 'test-secret',
-                        'created_at': '2021-09-09T12:00:00Z',
-                        'updated_at': '2021-09-09T12:00:00Z',
-                        'resource_type': 'secret',
-                        'spec': {
-                            'name': 'test-secret',
-                            'description': 'test-secret',
-                            'data': {'key': 'value'},
-                        }
-                    }],
-                },
-            }
+                }
             )
         ]
-        with patch.object(client.PRAXClient, '_request') as mock_request:
+        with patch.object(client.PRAXClient, "_request") as mock_request:
             mock_request.return_value = (response, None)
-            result = runner.invoke(main, ['prax', 'describe', 'user'])
+            result = runner.invoke(main, ["prax", "describe", "user"])
             assert result.exit_code == 0
-            assert 'test-user' in result.output
-            assert 'test-project' in result.output
-            assert 'test-secret' in result.output
+            assert "test-user" in result.output
+            assert "test-project" in result.output
+            assert "test-secret" in result.output

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,23 +1,18 @@
-import tempfile
 import os
-from io import BytesIO
-from unittest.mock import Mock, patch, mock_open
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
-from unittest.mock import Mock, patch, ANY
-from datetime import datetime, timezone
 from requests import Response
 
 from oceanum.cli import main
-from oceanum.cli.prax.workflows import (
-    list_pipelines, describe_pipeline, submit_pipeline,
-    terminate_pipeline, retry_pipeline, get_pipeline_logs
-)
+from oceanum.cli.models import TokenResponse
 from oceanum.cli.prax import models
-from oceanum.cli.models import TokenResponse, Auth0Config
 
 timestamp = datetime.now(tz=timezone.utc)
+
 
 @pytest.fixture
 def mock_response():
@@ -25,41 +20,94 @@ def mock_response():
     response.ok = True
     return response
 
+
 @pytest.fixture
 def mock_client(mock_response):
-    with patch('oceanum.cli.prax.client.PRAXClient._request') as mock:
+    with patch("oceanum.cli.prax.client.PRAXClient._request") as mock:
         # Configure mock to return (response, None) for success case
         mock_response.json.return_value = {}  # default empty response
         mock.return_value = (mock_response, None)
         yield mock
 
+
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 @pytest.fixture
 def error_response():
     response = Mock(spec=Response)
     response.ok = False
     response.status_code = 404
-    response.json.return_value = {
-        "status_code": 404,
-        "detail": "Not found"
-    }
+    response.json.return_value = {"status_code": 404, "detail": "Not found"}
     return response
+
 
 token = TokenResponse(
     access_token="test_token",
     token_type="Bearer",
     refresh_token="test_refresh_token",
-    expires_in=86400
+    expires_in=86400,
 )
+
 
 class TestPipelineCommands:
     def test_list_pipelines_success(self, runner, mock_client, mock_response):
         # Setup mock response
         mock_response = [
-            models.PipelineSchema(**{
+            models.PipelineSchema(
+                **{
+                    "id": "pipeline-123",
+                    "name": "test-pipeline",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "last_run": None,
+                }
+            )
+        ]
+        mock_client.return_value = (mock_response, None)
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "list", "pipelines"])
+            print(result.output)
+            assert result.exit_code == 0
+
+        # With filters
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "list", "pipelines", "--project=bla"])
+            assert result.exit_code == 0
+            mock_client.assert_called_with(
+                "GET",
+                "pipelines",
+                params={
+                    "project": "bla",
+                    "stage": None,
+                    "org": None,
+                    "search": None,
+                    "user": None,
+                },
+                schema=models.PipelineSchema,
+            )
+
+    def test_list_pipelines_error(self, runner, mock_client, error_response):
+        # Setup error response
+        mock_client.return_value = (
+            error_response,
+            models.ErrorResponse(detail="Not found"),
+        )
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "list", "pipelines"])
+            assert result.exit_code == 1
+            assert "Not found" in result.output
+
+    def test_describe_pipeline_success(self, runner, mock_client, mock_response):
+        mock_response = models.PipelineSchema(
+            **{
                 "id": "pipeline-123",
                 "name": "test-pipeline",
                 "project": "test-project",
@@ -67,231 +115,276 @@ class TestPipelineCommands:
                 "org": "test-org",
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "last_run": None
-            })
-        ]
+                "last_run": None,
+            }
+        )
         mock_client.return_value = (mock_response, None)
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'list', 'pipelines'])
-            print(result.output)
-            assert result.exit_code == 0
-
-        # With filters
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'list', 'pipelines', '--project=bla'])
-            assert result.exit_code == 0
-            mock_client.assert_called_with("GET", "pipelines", 
-                params={"project": "bla", "stage": None, "org": None, 'search': None, 'user': None},
-                schema=models.PipelineSchema
-            )
-
-    def test_list_pipelines_error(self, runner, mock_client, error_response):
-        # Setup error response
-        mock_client.return_value = (error_response, models.ErrorResponse(detail="Not found"))
-
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-
-            result = runner.invoke(main, ['prax', 'list', 'pipelines'])
-            assert result.exit_code == 1
-            assert "Not found" in result.output
-
-    def test_describe_pipeline_success(self, runner, mock_client, mock_response):
-        mock_response = models.PipelineSchema(**{
-            "id": "pipeline-123",
-            "name": "test-pipeline",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": None
-        })
-        mock_client.return_value = (mock_response, None)
-
-        result = runner.invoke(main, ['prax', 'describe', 'pipeline', 'test-pipeline'])
+        result = runner.invoke(main, ["prax", "describe", "pipeline", "test-pipeline"])
         assert result.exit_code == 0
-        mock_client.assert_called_with("GET", "pipelines/test-pipeline", 
-            params={"org": None, 'user': None, 'project': None, 'stage': None},
-            schema=models.PipelineSchema
+        mock_client.assert_called_with(
+            "GET",
+            "pipelines/test-pipeline",
+            params={"org": None, "user": None, "project": None, "stage": None},
+            schema=models.PipelineSchema,
         )
 
         # Test with filters
-        result = runner.invoke(main, ['prax', 'describe', 'pipeline', 'test-pipeline','--project=bla'])
+        result = runner.invoke(
+            main, ["prax", "describe", "pipeline", "test-pipeline", "--project=bla"]
+        )
         assert result.exit_code == 0
-        mock_client.assert_called_with("GET", "pipelines/test-pipeline", 
-            params={"org": None, 'user': None, 'project': 'bla', 'stage': None},
-            schema=models.PipelineSchema
+        mock_client.assert_called_with(
+            "GET",
+            "pipelines/test-pipeline",
+            params={"org": None, "user": None, "project": "bla", "stage": None},
+            schema=models.PipelineSchema,
         )
 
     def test_submit_pipeline_success(self, runner, mock_client, mock_response):
-        mock_response = models.PipelineSchema(**{
-            "id": "pipeline-123",
-            "name": "test-pipeline",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
+        mock_response = models.PipelineSchema(
+            **{
+                "id": "pipeline-123",
+                "name": "test-pipeline",
                 "project": "test-project",
                 "stage": "dev",
                 "org": "test-org",
-                "parent": 'pipeline-123',
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
-                "runs": []
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "parent": "pipeline-123",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                    "runs": [],
+                },
             }
-        })
+        )
         mock_client.return_value = (mock_response, None)
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'submit', 'pipeline', 'test-pipeline'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(
+                main, ["prax", "submit", "pipeline", "test-pipeline"]
+            )
             assert result.exit_code == 0
             assert "Pipeline submitted successfully" in result.output
         # with filters and parameters
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'submit', 'pipeline', 'test-pipeline', '--project', 'bla', '-p', 'key=val'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(
+                main,
+                [
+                    "prax",
+                    "submit",
+                    "pipeline",
+                    "test-pipeline",
+                    "--project",
+                    "bla",
+                    "-p",
+                    "key=val",
+                ],
+            )
             assert result.exit_code == 0
             assert "Pipeline submitted successfully" in result.output
-            mock_client.assert_called_with("POST", "pipelines/test-pipeline/submit", 
+            mock_client.assert_called_with(
+                "POST",
+                "pipelines/test-pipeline/submit",
                 json={"parameters": {"key": "val"}},
                 params={"project": "bla", "org": None, "user": None, "stage": None},
-                schema=models.PipelineSchema
+                schema=models.PipelineSchema,
             )
 
-
-
     def test_terminate_pipeline_success(self, runner, mock_client, mock_response):
-        mock_response = models.StagedRunSchema(**{
-            "id": "pipeline-123",
-            "name": "test-pipeline",
-            "object_ref": models.ObjectRef(root="pipeline-123"),
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "parent": 'pipeline-123',
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "status": "running",
-        })
+        mock_response = models.StagedRunSchema(
+            **{
+                "id": "pipeline-123",
+                "name": "test-pipeline",
+                "object_ref": models.ObjectRef(root="pipeline-123"),
+                "project": "test-project",
+                "stage": "dev",
+                "org": "test-org",
+                "parent": "pipeline-123",
+                "created_at": timestamp,
+                "updated_at": timestamp,
+                "status": "running",
+            }
+        )
         mock_client.return_value = (mock_response, None)
-        result = runner.invoke(main, ['prax', 'terminate', 'pipeline', 'test-pipeline'])
+        result = runner.invoke(main, ["prax", "terminate", "pipeline", "test-pipeline"])
         print(result.output)
         assert result.exit_code == 0
         assert "Pipeline terminated successfully" in result.output
 
     def test_retry_pipeline_success(self, runner, mock_client, mock_response):
-        mock_response = models.StagedRunSchema(**{
-            "id": "pipeline-123",
-            "name": "test-pipeline",
-            "project": "test-project",
-            "object_ref": models.ObjectRef(root="pipeline-123"),
-            "stage": "dev",
-            "org": "test-org",
-            "parent": 'pipeline-123',
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "status": "failed",
-        })
+        mock_response = models.StagedRunSchema(
+            **{
+                "id": "pipeline-123",
+                "name": "test-pipeline",
+                "project": "test-project",
+                "object_ref": models.ObjectRef(root="pipeline-123"),
+                "stage": "dev",
+                "org": "test-org",
+                "parent": "pipeline-123",
+                "created_at": timestamp,
+                "updated_at": timestamp,
+                "status": "failed",
+            }
+        )
         mock_client.return_value = (mock_response, None)
 
-        result = runner.invoke(main, ['prax', 'retry', 'pipeline', 'test-pipeline'])
+        result = runner.invoke(main, ["prax", "retry", "pipeline", "test-pipeline"])
         assert result.exit_code == 0
         assert "Pipeline retried successfully" in result.output
 
     def test_delete_pipeline_run_success(self, runner, mock_client, mock_response):
         mock_client.return_value = ("Pipeline run deleted successfully!", None)
-        with patch('oceanum.cli.prax.client.PRAXClient.get_pipeline_run', 
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_pipeline_run",
             return_value=models.StagedRunSchema(
                 id="run-123",
                 name="test-pipeline",
                 project="test-project",
-                parent= 'pipeline-123',
+                parent="pipeline-123",
                 stage="dev",
                 org="test-org",
                 created_at=timestamp,
                 updated_at=timestamp,
                 status="succeeded",
-        )):
-            with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-                result = runner.invoke(main, ['prax', 'delete', 'pipeline', 'test-pipeline'])
+            ),
+        ):
+            with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+                result = runner.invoke(
+                    main, ["prax", "delete", "pipeline", "test-pipeline"]
+                )
                 assert result.exit_code == 0
                 assert "deleted successfully" in result.output
-                mock_client.assert_called_with("DELETE", "pipeline-runs/test-pipeline", 
-                    params={"project": None, "org": None, "user": None, "stage": None}
+                mock_client.assert_called_with(
+                    "DELETE",
+                    "pipeline-runs/test-pipeline",
+                    params={"project": None, "org": None, "user": None, "stage": None},
                 )
 
     def test_get_pipeline_logs(self, runner, mock_client, mock_response):
-        pipeline_get_response = models.PipelineSchema(**{
-            "id": "pipeline-123",
-            "name": "test-pipeline",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
+        pipeline_get_response = models.PipelineSchema(
+            **{
+                "id": "pipeline-123",
+                "name": "test-pipeline",
                 "project": "test-project",
                 "stage": "dev",
                 "org": "test-org",
-                "parent": 'pipeline-123',
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "parent": "pipeline-123",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                },
             }
-        })
-        #mock_response.content.return_value = ["Log line 1", "Log line 2"]
+        )
+        # mock_response.content.return_value = ["Log line 1", "Log line 2"]
         mock_response.iter_lines.return_value = iter(["Log line 1", "Log line 2"])
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.client.PRAXClient.get_pipeline') as mock_get_pipeline:
-                mock_get_pipeline.return_value =  pipeline_get_response
-                result = runner.invoke(main, ['prax', 'logs', 'pipeline', 'test-pipeline'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.get_pipeline"
+            ) as mock_get_pipeline:
+                mock_get_pipeline.return_value = pipeline_get_response
+                result = runner.invoke(
+                    main, ["prax", "logs", "pipeline", "test-pipeline"]
+                )
                 assert result.exit_code == 0
                 assert "Log line 1" in result.output
                 assert "Log line 2" in result.output
 
     def test_get_pipeline_logs_with_options(self, runner, mock_client, mock_response):
         # Mock the response for the pipeline
-        pipeline_get_response = models.PipelineSchema(**{
-            "id": "pipeline-123",
-            "name": "test-pipeline",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
-                "parent": 'pipeline-123',
+        pipeline_get_response = models.PipelineSchema(
+            **{
+                "id": "pipeline-123",
+                "name": "test-pipeline",
                 "project": "test-project",
                 "stage": "dev",
                 "org": "test-org",
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "parent": "pipeline-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                },
             }
-        })
+        )
         mock_response.iter_lines.return_value = iter(["Log line 1", "Log line 2"])
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.client.PRAXClient.get_pipeline') as mock_get_pipeline:
-                mock_get_pipeline.return_value =  pipeline_get_response
-                result = runner.invoke(main, ['prax', 'logs', 'pipeline', 'test-pipeline', '--follow'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.get_pipeline"
+            ) as mock_get_pipeline:
+                mock_get_pipeline.return_value = pipeline_get_response
+                result = runner.invoke(
+                    main, ["prax", "logs", "pipeline", "test-pipeline", "--follow"]
+                )
                 assert result.exit_code == 0
                 assert "Log line 1" in result.output
+
 
 class TestTaskCommands:
     def test_list_tasks_success(self, runner, mock_client, mock_response):
         mock_response = [
-            models.TaskSchema(**{
+            models.TaskSchema(
+                **{
+                    "id": "task-123",
+                    "name": "test-task",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "last_run": None,
+                }
+            )
+        ]
+        mock_client.return_value = (mock_response, None)
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "list", "tasks"])
+            assert result.exit_code == 0
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "list", "tasks", "--project=bla"])
+            assert result.exit_code == 0
+            mock_client.assert_called_with(
+                "GET",
+                "tasks",
+                params={
+                    "project": "bla",
+                    "stage": None,
+                    "org": None,
+                    "search": None,
+                    "user": None,
+                },
+                schema=models.TaskSchema,
+            )
+
+    def test_describe_task_success(self, runner, mock_client, mock_response):
+        mock_response = models.TaskSchema(
+            **{
                 "id": "task-123",
                 "name": "test-task",
                 "project": "test-project",
@@ -299,129 +392,139 @@ class TestTaskCommands:
                 "org": "test-org",
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "last_run": None
-            })
-        ]
+                "last_run": None,
+            }
+        )
         mock_client.return_value = (mock_response, None)
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'list', 'tasks'])
-            assert result.exit_code == 0
-
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'list', 'tasks', '--project=bla'])
-            assert result.exit_code == 0
-            mock_client.assert_called_with("GET", "tasks", 
-                params={"project": "bla", "stage": None, "org": None, 'search': None, 'user': None},
-                schema=models.TaskSchema
-            )
-
-    def test_describe_task_success(self, runner, mock_client, mock_response):
-        mock_response = models.TaskSchema(**{
-            "id": "task-123",
-            "name": "test-task",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": None
-        })
-        mock_client.return_value = (mock_response, None)
-
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'describe', 'task', 'test-task'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "describe", "task", "test-task"])
             assert result.exit_code == 0
 
     def test_submit_task_success(self, runner, mock_client, mock_response):
-        mock_response = models.TaskSchema(**{
-            "id": "task-123",
-            "name": "test-task",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
+        mock_response = models.TaskSchema(
+            **{
+                "id": "task-123",
+                "name": "test-task",
                 "project": "test-project",
                 "stage": "dev",
-                "parent": 'task-123',
                 "org": "test-org",
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "parent": "task-123",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                },
             }
-        })
+        )
         mock_client.return_value = (mock_response, None)
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'submit', 'task', 'test-task', '-p', 'key=val'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(
+                main, ["prax", "submit", "task", "test-task", "-p", "key=val"]
+            )
             assert result.exit_code == 0
             assert "Task submitted successfully" in result.output
-            mock_client.assert_called_with("POST", "tasks/test-task/submit", 
+            mock_client.assert_called_with(
+                "POST",
+                "tasks/test-task/submit",
                 json={"parameters": {"key": "val"}},
                 params={"project": None, "org": None, "user": None, "stage": None},
-                schema=models.TaskSchema
+                schema=models.TaskSchema,
             )
 
     def test_get_task_logs(self, runner, mock_client, mock_response):
-        task_response = models.TaskSchema(**{
-            "id": "task-123",
-            "name": "test-task",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
+        task_response = models.TaskSchema(
+            **{
+                "id": "task-123",
+                "name": "test-task",
                 "project": "test-project",
                 "stage": "dev",
-                "parent": 'task-123',
                 "org": "test-org",
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "parent": "task-123",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                },
             }
-        })
+        )
         mock_response.iter_lines.return_value = iter(["Log line 1", "Log line 2"])
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.client.PRAXClient.get_task') as mock_get_task:
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.client.PRAXClient.get_task") as mock_get_task:
                 mock_get_task.return_value = task_response
-                result = runner.invoke(main, ['prax', 'logs', 'task', 'test-task'])
+                result = runner.invoke(main, ["prax", "logs", "task", "test-task"])
                 assert result.exit_code == 0
                 assert "Log line 1" in result.output
 
     def test_delete_task_run_success(self, runner, mock_client, mock_response):
         mock_client.return_value = ("Task run deleted successfully!", None)
-        with patch('oceanum.cli.prax.client.PRAXClient.get_task_run', 
-                   return_value=models.StagedRunSchema(
-            id="run-123",
-            name="test-task",
-            project="test-project",
-            stage="dev",
-            org="test-org",
-            parent= 'task-123',
-            created_at=timestamp,
-            updated_at=timestamp,
-            status="succeeded",
-        )):
-            with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-                result = runner.invoke(main, ['prax', 'delete', 'task', 'test-task'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_task_run",
+            return_value=models.StagedRunSchema(
+                id="run-123",
+                name="test-task",
+                project="test-project",
+                stage="dev",
+                org="test-org",
+                parent="task-123",
+                created_at=timestamp,
+                updated_at=timestamp,
+                status="succeeded",
+            ),
+        ):
+            with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+                result = runner.invoke(main, ["prax", "delete", "task", "test-task"])
                 assert result.exit_code == 0
                 assert "deleted successfully" in result.output
-                mock_client.assert_called_with("DELETE", "task-runs/test-task", 
-                    params={"project": None, "org": None, "user": None, "stage": None}
+                mock_client.assert_called_with(
+                    "DELETE",
+                    "task-runs/test-task",
+                    params={"project": None, "org": None, "user": None, "stage": None},
                 )
+
 
 class TestBuildCommands:
     def test_list_builds_success(self, runner, mock_client, mock_response):
         mock_response = [
-            models.BuildSchema(**{
+            models.BuildSchema(
+                **{
+                    "id": "build-123",
+                    "name": "test-build",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "source_ref": "main",
+                    "last_run": None,
+                }
+            )
+        ]
+        mock_client.return_value = (mock_response, None)
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "list", "builds"])
+            assert result.exit_code == 0
+
+    def test_describe_build_success(self, runner, mock_client, mock_response):
+        mock_response = models.BuildSchema(
+            **{
                 "id": "build-123",
                 "name": "test-build",
                 "project": "test-project",
@@ -430,119 +533,112 @@ class TestBuildCommands:
                 "created_at": timestamp,
                 "updated_at": timestamp,
                 "source_ref": "main",
-                "last_run": None
-            })
-        ]
+                "commit_sha": "abc123",
+                "last_run": None,
+            }
+        )
         mock_client.return_value = (mock_response, None)
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'list', 'builds'])
-            assert result.exit_code == 0
-
-    def test_describe_build_success(self, runner, mock_client, mock_response):
-        mock_response = models.BuildSchema(**{
-            "id": "build-123",
-            "name": "test-build",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "source_ref": "main",
-            "commit_sha": "abc123",
-            "last_run": None
-        })
-        mock_client.return_value = (mock_response, None)
-
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'describe', 'build', 'test-build'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "describe", "build", "test-build"])
             assert result.exit_code == 0
 
     def test_submit_build_success(self, runner, mock_client, mock_response):
-        mock_response = models.BuildSchema(**{
-            "id": "build-123",
-            "name": "test-build",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "source_ref": "main",
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
+        mock_response = models.BuildSchema(
+            **{
+                "id": "build-123",
+                "name": "test-build",
                 "project": "test-project",
                 "stage": "dev",
                 "org": "test-org",
-                "parent": 'build-123',
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
+                "source_ref": "main",
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "org": "test-org",
+                    "parent": "build-123",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                },
             }
-        })
+        )
         mock_client.return_value = (mock_response, None)
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, ['prax', 'submit', 'build', 'test-build'])
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(main, ["prax", "submit", "build", "test-build"])
             assert result.exit_code == 0
             assert "Build submitted successfully" in result.output
 
     def test_get_build_logs(self, runner, mock_client, mock_response):
-        build_response = models.BuildSchema(**{
-            "id": "build-123",
-            "name": "test-build",
-            "project": "test-project",
-            "stage": "dev",
-            "org": "test-org",
-            "created_at": timestamp,
-            "updated_at": timestamp,
-            "source_ref": "main",
-            "last_run": {
-                "id": "run-123",
-                "name": "run-123",
+        build_response = models.BuildSchema(
+            **{
+                "id": "build-123",
+                "name": "test-build",
                 "project": "test-project",
                 "stage": "dev",
-                "parent": 'build-123',
                 "org": "test-org",
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "status": "running",
+                "source_ref": "main",
+                "last_run": {
+                    "id": "run-123",
+                    "name": "run-123",
+                    "project": "test-project",
+                    "stage": "dev",
+                    "parent": "build-123",
+                    "org": "test-org",
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "status": "running",
+                },
             }
-        })
+        )
         mock_response.iter_lines.return_value = iter(["Log line 1", "Log line 2"])
 
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.client.PRAXClient.get_build') as mock_get_build:
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch(
+                "oceanum.cli.prax.client.PRAXClient.get_build"
+            ) as mock_get_build:
                 mock_get_build.return_value = build_response
-                result = runner.invoke(main, ['prax', 'logs', 'build', 'test-build'])
+                result = runner.invoke(main, ["prax", "logs", "build", "test-build"])
                 assert result.exit_code == 0
                 assert "Log line 1" in result.output
 
-
     def test_delete_build_run_success(self, runner, mock_client, mock_response):
         mock_client.return_value = ("Build run deleted successfully!", None)
-        with patch('oceanum.cli.prax.client.PRAXClient.get_build_run', return_value=models.StagedRunSchema(
-            id="run-123",
-            name="test-build",
-            project="test-project",
-            stage="dev",
-            org="test-org",
-            created_at=timestamp,
-            updated_at=timestamp,
-            parent= 'build-123',
-            status="succeeded",
-        )):
-            with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-                result = runner.invoke(main, ['prax', 'delete', 'build', 'test-build'])
+        with patch(
+            "oceanum.cli.prax.client.PRAXClient.get_build_run",
+            return_value=models.StagedRunSchema(
+                id="run-123",
+                name="test-build",
+                project="test-project",
+                stage="dev",
+                org="test-org",
+                created_at=timestamp,
+                updated_at=timestamp,
+                parent="build-123",
+                status="succeeded",
+            ),
+        ):
+            with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+                result = runner.invoke(main, ["prax", "delete", "build", "test-build"])
                 print(result.output)
                 assert result.exit_code == 0
                 assert "deleted successfully" in result.output
-                mock_client.assert_called_with("DELETE", "build-runs/test-build", 
-                    params={"project": None, "org": None, "user": None, "stage": None}
+                mock_client.assert_called_with(
+                    "DELETE",
+                    "build-runs/test-build",
+                    params={"project": None, "org": None, "user": None, "stage": None},
                 )
 
 
 # Add these test classes to your existing test file
+
 
 class TestDownloadCommands:
     def test_download_task_artifact_success(self, runner, mock_client, mock_response):
@@ -553,64 +649,86 @@ class TestDownloadCommands:
             project="test-project",
             stage="dev",
             name="test-task-run-123",
-            parent= 'task-123',
+            parent="task-123",
             status="Succeeded",
             created_at=timestamp,
             updated_at=timestamp,
-            message="Completed successfully"
+            message="Completed successfully",
         )
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            output_path = os.path.join(temp_dir, 'test_artifact.gz')
-            
-            with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-                with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+            output_path = os.path.join(temp_dir, "test_artifact.gz")
+
+            with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+                with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                     client_instance = Mock()
                     client_instance.get_task_run.return_value = mock_task_run
                     client_instance.download_task_run_artifact.return_value = True
                     mock_prax_client.return_value = client_instance
-                    
-                    result = runner.invoke(main, [
-                        'prax', 'download', 'task-artifact', 'test-task-run-123',
-                        '--artifact-name', 'test-artifact',
-                        '--output', output_path
-                    ])
+
+                    result = runner.invoke(
+                        main,
+                        [
+                            "prax",
+                            "download",
+                            "task-artifact",
+                            "test-task-run-123",
+                            "--artifact-name",
+                            "test-artifact",
+                            "--output",
+                            output_path,
+                        ],
+                    )
                     print(result.output)
                     assert result.exit_code == 0
-                    assert "Artifact 'test-artifact' downloaded successfully!" in result.output
-                    
+                    assert (
+                        "Artifact 'test-artifact' downloaded successfully!"
+                        in result.output
+                    )
+
                     # Verify the client calls
-                    client_instance.get_task_run.assert_called_once_with("test-task-run-123")
+                    client_instance.get_task_run.assert_called_once_with(
+                        "test-task-run-123"
+                    )
                     client_instance.download_task_run_artifact.assert_called_once_with(
                         "test-task-run-123", "test-artifact", output_path
                     )
 
-    def test_download_task_artifact_default_path(self, runner, mock_client, mock_response):
+    def test_download_task_artifact_default_path(
+        self, runner, mock_client, mock_response
+    ):
         mock_task_run = models.StagedRunSchema(
             id="test-task-run-123",
             org="test-org",
             project="test-project",
             stage="dev",
-            parent= 'task-123',
+            parent="task-123",
             name="test-task-run-123",
             status="Succeeded",
             created_at=timestamp,
             updated_at=timestamp,
-            message="Completed successfully"
+            message="Completed successfully",
         )
-        
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                 client_instance = Mock()
                 client_instance.get_task_run.return_value = mock_task_run
                 client_instance.download_task_run_artifact.return_value = True
                 mock_prax_client.return_value = client_instance
-                
-                result = runner.invoke(main, [
-                    'prax', 'download', 'task-artifact', 'test-task-run',
-                    '--artifact-name', 'test-artifact'
-                ])
-                
+
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "download",
+                        "task-artifact",
+                        "test-task-run",
+                        "--artifact-name",
+                        "test-artifact",
+                    ],
+                )
+
                 assert result.exit_code == 0
                 # Should use None for output path (default behavior)
                 client_instance.download_task_run_artifact.assert_called_once_with(
@@ -619,18 +737,25 @@ class TestDownloadCommands:
 
     def test_download_task_artifact_task_not_found(self, runner, mock_client):
         error_response = models.ErrorResponse(detail="Task run not found!")
-        
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                 client_instance = Mock()
                 client_instance.get_task_run.return_value = error_response
                 mock_prax_client.return_value = client_instance
-                
-                result = runner.invoke(main, [
-                    'prax', 'download', 'task-artifact', 'nonexistent-task',
-                    '--artifact-name', 'test-artifact'
-                ])
-                
+
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "download",
+                        "task-artifact",
+                        "nonexistent-task",
+                        "--artifact-name",
+                        "test-artifact",
+                    ],
+                )
+
                 assert result.exit_code == 1
                 assert "Error fetching task run:" in result.output
 
@@ -641,76 +766,109 @@ class TestDownloadCommands:
             project="test-project",
             stage="dev",
             name="test-task-run-123",
-            parent= 'task-123',
+            parent="task-123",
             status="Succeeded",
             created_at=timestamp,
             updated_at=timestamp,
-            message="Completed successfully"
+            message="Completed successfully",
         )
-        
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                 client_instance = Mock()
                 client_instance.get_task_run.return_value = mock_task_run
                 client_instance.download_task_run_artifact.return_value = False
                 mock_prax_client.return_value = client_instance
-                
-                result = runner.invoke(main, [
-                    'prax', 'download', 'task-artifact', 'test-task-run',
-                    '--artifact-name', 'test-artifact'
-                ])
-                
-                # Should not print success message if download returns False
-                assert "Artifact 'test-artifact' downloaded successfully!" not in result.output
 
-    def test_download_pipeline_artifact_success(self, runner, mock_client, mock_response):
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "download",
+                        "task-artifact",
+                        "test-task-run",
+                        "--artifact-name",
+                        "test-artifact",
+                    ],
+                )
+
+                # Should not print success message if download returns False
+                assert (
+                    "Artifact 'test-artifact' downloaded successfully!"
+                    not in result.output
+                )
+
+    def test_download_pipeline_artifact_success(
+        self, runner, mock_client, mock_response
+    ):
         mock_pipeline_run = models.StagedRunSchema(
             id="test-pipeline-run-456",
             org="test-org",
             project="test-project",
             stage="dev",
-            parent= 'pipeline-123',
+            parent="pipeline-123",
             name="test-pipeline-run-456",
             status="Succeeded",
             created_at=timestamp,
             updated_at=timestamp,
-            message="Pipeline completed successfully"
+            message="Pipeline completed successfully",
         )
-        
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                 client_instance = Mock()
                 client_instance.get_pipeline_run.return_value = mock_pipeline_run
                 client_instance.download_pipeline_run_artifact.return_value = True
                 mock_prax_client.return_value = client_instance
-                
-                result = runner.invoke(main, [
-                    'prax', 'download', 'pipeline-artifact', 'test-pipeline-run',
-                    '--artifact-name', 'test-artifact',
-                    '--step-name', 'test-step',
-                    '--output', '/tmp/pipeline_artifact.gz'
-                ])
-                
+
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "download",
+                        "pipeline-artifact",
+                        "test-pipeline-run",
+                        "--artifact-name",
+                        "test-artifact",
+                        "--step-name",
+                        "test-step",
+                        "--output",
+                        "/tmp/pipeline_artifact.gz",
+                    ],
+                )
+
                 assert result.exit_code == 0
-                assert "Artifact 'test-artifact' from step 'test-step' downloaded successfully!" in result.output
-                
+                assert (
+                    "Artifact 'test-artifact' from step 'test-step' downloaded successfully!"
+                    in result.output
+                )
+
                 # Verify the client calls
                 client_instance.get_pipeline_run.assert_called_once_with(
-                    "test-pipeline-run", 
-                    org=None, user=None, project=None, stage=None
+                    "test-pipeline-run", org=None, user=None, project=None, stage=None
                 )
                 client_instance.download_pipeline_run_artifact.assert_called_once_with(
-                    "test-pipeline-run-456", "test-artifact", "test-step", "/tmp/pipeline_artifact.gz"
+                    "test-pipeline-run-456",
+                    "test-artifact",
+                    "test-step",
+                    "/tmp/pipeline_artifact.gz",
                 )
 
     def test_download_pipeline_artifact_missing_step_name(self, runner, mock_client):
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            result = runner.invoke(main, [
-                'prax', 'download', 'pipeline-artifact', 'test-pipeline-run',
-                '--artifact-name', 'test-artifact'
-                # Missing --step-name
-            ])
-            
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            result = runner.invoke(
+                main,
+                [
+                    "prax",
+                    "download",
+                    "pipeline-artifact",
+                    "test-pipeline-run",
+                    "--artifact-name",
+                    "test-artifact",
+                    # Missing --step-name
+                ],
+            )
+
             # Should fail due to missing required step-name argument
             assert result.exit_code != 0
             assert "Missing option" in result.output or "Error" in result.output
@@ -721,15 +879,15 @@ class TestDownloadCommands:
             id="test-pipeline-run-456",
             org="test-org",
             project="test-project",
-            parent= 'pipeline-123',
+            parent="pipeline-123",
             stage="dev",
             name="test-pipeline-run-456",
             status="Succeeded",
             created_at=timestamp,
             updated_at=timestamp,
-            message="Pipeline completed successfully"
+            message="Pipeline completed successfully",
         )
-        
+
         mock_pipeline = models.PipelineSchema(
             id="pipeline-123",
             name="test-pipeline",
@@ -738,24 +896,32 @@ class TestDownloadCommands:
             org="test-org",
             created_at=timestamp,
             updated_at=timestamp,
-            last_run=mock_pipeline_run
+            last_run=mock_pipeline_run,
         )
-        
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                 client_instance = Mock()
                 client_instance.get_pipeline.return_value = mock_pipeline
                 client_instance.download_pipeline_run_artifact.return_value = True
                 mock_prax_client.return_value = client_instance
-                
-                result = runner.invoke(main, [
-                    'prax', 'download', 'pipeline-artifact', 'test-pipeline',
-                    '--artifact-name', 'test-artifact',
-                    '--step-name', 'test-step'
-                ])
-                
+
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "download",
+                        "pipeline-artifact",
+                        "test-pipeline",
+                        "--artifact-name",
+                        "test-artifact",
+                        "--step-name",
+                        "test-step",
+                    ],
+                )
+
                 assert result.exit_code == 0
-                
+
                 # Should use the last_run from the pipeline schema
                 client_instance.download_pipeline_run_artifact.assert_called_once_with(
                     "test-pipeline-run-456", "test-artifact", "test-step", None
@@ -771,21 +937,31 @@ class TestDownloadCommands:
             org="test-org",
             created_at=timestamp,
             updated_at=timestamp,
-            last_run=None
+            last_run=None,
         )
-        
-        with patch('oceanum.cli.models.TokenResponse.load', return_value=token):
-            with patch('oceanum.cli.prax.workflows.PRAXClient') as mock_prax_client:
+
+        with patch("oceanum.cli.models.TokenResponse.load", return_value=token):
+            with patch("oceanum.cli.prax.workflows.PRAXClient") as mock_prax_client:
                 client_instance = Mock()
                 client_instance.get_pipeline.return_value = mock_pipeline
                 client_instance.get_pipeline_run.return_value = None
                 mock_prax_client.return_value = client_instance
-                
-                result = runner.invoke(main, [
-                    'prax', 'download', 'pipeline-artifact', 'test-pipeline',
-                    '--artifact-name', 'test-artifact',
-                    '--step-name', 'test-step'
-                ])
-                
+
+                result = runner.invoke(
+                    main,
+                    [
+                        "prax",
+                        "download",
+                        "pipeline-artifact",
+                        "test-pipeline",
+                        "--artifact-name",
+                        "test-artifact",
+                        "--step-name",
+                        "test-step",
+                    ],
+                )
+
                 assert result.exit_code == 1
-                assert "No pipeline run found for pipeline: test-pipeline" in result.output
+                assert (
+                    "No pipeline run found for pipeline: test-pipeline" in result.output
+                )


### PR DESCRIPTION
- Configure ruff with 88-char line length and lenient rules (E, F, I, W)
- Add pre-commit hooks for automated formatting and linting
- Add pytest-xdist for parallel test execution
- Update CI workflow with dedicated lint job and parallel testing
- Format entire codebase with ruff
- Fix command registration by importing modules in __init__.py
- Update README with development setup documentation
- Exclude auto-generated models.py from linting
- Add .pre-commit-config.yaml with ruff and general cleanup hooks

All 77 tests passing with 80% code coverage.